### PR TITLE
feat: send error code from ChatGPT along with error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ If no sessions have finished initializing yet:
 If there was an error sending the message to ChatGPT:
 ```JSON
 {
-    "error": "There was an error communicating with ChatGPT."
+    "error": "There was an error communicating with ChatGPT.",
+    "code": "message_length_exceeds_limit" // will change depending on the specific error
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ server.post('/conversation', async (request, reply) => {
         reply.send(result);
     } else {
         console.error(error);
-        reply.code(503).send({ error: 'There was an error communicating with ChatGPT.' });
+        reply.code(503).send({ error: 'There was an error communicating with ChatGPT.', code: error.code });
     }
 });
 


### PR DESCRIPTION
When there is an error communicating with ChatGPT, such as a message exceeding the length limit, the error code is not currently being sent. This makes it difficult to determine the cause of the error and handle it properly. 

In this PR I'm sending the prop `code` with the one received from ChatGPT.

For example, when the message length exceeds the limit,, we get this response from a 413, but we are not currently using it:
```js
{
    message: 'The message you submitted was too long, please reload the conversation and submit something shorter.',
    code: 'message_length_exceeds_limit'
}
```

With this suggested change, we'll be able to handle specific errors by reading the `code` prop and act accordingly.