### PR TITLE
fix(settings): ERR_UNSUPPORTED_ESM_URL_SCHEME errors on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import fastify from 'fastify';
 import { ChatGPTAPIBrowser } from 'chatgpt';
 import fs from 'fs';
+import { pathToFileURL } from 'url'
 
 const arg = process.argv.find((arg) => arg.startsWith('--settings'));
 let path;
@@ -15,7 +16,7 @@ let settings;
 if (fs.existsSync(path)) {
     // get the full path
     const fullPath = fs.realpathSync(path);
-    settings = (await import(fullPath)).default;
+    settings = (await import(pathToFileURL(fullPath).toString())).default;
 } else {
     if (arg) {
         console.error(`Error: the file specified by the --settings parameter does not exist.`);


### PR DESCRIPTION
```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at new NodeError (node:internal/errors:400:5)
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1055:11)
    at defaultResolve (node:internal/modules/esm/resolve:1135:3)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:842:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ESMLoader.import (node:internal/modules/esm/loader:525:22)
    at importModuleDynamically (node:internal/modules/esm/translators:110:35)
    at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
    at file:///C:/Users/aiqin/AppData/Roaming/npm/node_modules/@waylaidwanderer/chatgpt-api/index.js:18:5 {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```