### PR TITLE
Revert "feat: send error code from ChatGPT along with error message"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ If no sessions have finished initializing yet:
 If there was an error sending the message to ChatGPT:
 ```JSON
 {
-    "error": "There was an error communicating with ChatGPT.",
-    "code": "message_length_exceeds_limit" // will change depending on the specific error
+    "error": "There was an error communicating with ChatGPT."
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ server.post('/conversation', async (request, reply) => {
         reply.send(result);
     } else {
         console.error(error);
-        reply.code(503).send({ error: 'There was an error communicating with ChatGPT.', code: error.code });
+        reply.code(503).send({ error: 'There was an error communicating with ChatGPT.' });
     }
 });
 


### PR DESCRIPTION
Unfortunately, the error code is not being returned from `sendMessage` (it's only logged, not sure why), so we can't use it at this moment. I requested this feature here https://github.com/transitive-bullshit/chatgpt-api/issues/272

I'll be following the thread so we can add it when possible.

Reverts waylaidwanderer/node-chatgpt-api#7