### PR TITLE
fix(client): updated fastify host binding to support proper docker deployment

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -68,7 +68,7 @@ server.post('/conversation', async (request, reply) => {
     }
 });
 
-server.listen({ port: settings.port || 3000 }, (error) => {
+server.listen({ port: settings.port || 3000, host: '0.0.0.0'}, (error) => {
     if (error) {
         console.error(error);
         process.exit(1);


### PR DESCRIPTION
This will allow for a standalone Docker build. And is a part of attempting to resolve issue #3.
See my [repo](https://github.com/queercat/gpt-api-docker) that resolves #3 once this is resolved. 

The reason this isn't working is docker cannot support the 127.0.0.1 binding only 0.0.0.0 (which Fastify prefers anyway afaik.)