### PR TITLE
fix(browser-client): avoid cache null data

### DIFF
--- a/src/ChatGPTBrowserClient.js
+++ b/src/ChatGPTBrowserClient.js
@@ -149,7 +149,8 @@ export default class ChatGPTBrowserClient {
         let conversation;
         if (conversationId) {
             conversation = await this.conversationsCache.get(conversationId);
-        } else {
+        }
+        if (!conversation) {
             conversation = {
                 messages: [],
                 createdAt: Date.now(),


### PR DESCRIPTION
This will double check conversation in case conversationsCache not exists.