### PR TITLE
fix(server): jailbreak conversation cache fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ module.exports = {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', "sydney", 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ This takes an optional `--settings=<path_to_settings.js>` parameter, or looks fo
 module.exports = {
     // Options for the Keyv cache, see https://www.npmjs.com/package/keyv.
     // This is used for storing conversations, and supports additional drivers (conversations are stored in memory by default).
-    // Only applies when using `ChatGPTClient`.
+    // Only applies when using `ChatGPTClient` or `BingAIClient`.
     cacheOptions: {},
-    // If set, `ChatGPTClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
+    // If set, `ChatGPTClient` and `BingAIClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
     // However, `cacheOptions.store` will override this if set
     storageFilePath: process.env.STORAGE_FILE_PATH || './cache.json',
     chatGptClient: {
@@ -249,7 +249,7 @@ module.exports = {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', "sydney", 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This takes an optional `--settings=<path_to_settings.js>` parameter, or looks fo
 module.exports = {
     // Options for the Keyv cache, see https://www.npmjs.com/package/keyv.
     // This is used for storing conversations, and supports additional drivers (conversations are stored in memory by default).
-    // Only applies when using `ChatGPTClient` or `BingAIClient`.
+    // Only necessary when using `ChatGPTClient`, or `BingAIClient` in jailbreak mode.
     cacheOptions: {},
     // If set, `ChatGPTClient` and `BingAIClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
     // However, `cacheOptions.store` will override this if set

--- a/bin/server.js
+++ b/bin/server.js
@@ -162,8 +162,6 @@ function nextTick() {
 function getClient(clientToUseForMessage) {
     switch (clientToUseForMessage) {
         case 'bing':
-            return new BingAIClient(settings.bingAiClient);
-        case 'sydney':
             return new BingAIClient({ ...settings.bingAiClient, cache: settings.cacheOptions });
         case 'chatgpt-browser':
             return new ChatGPTBrowserClient(

--- a/bin/server.js
+++ b/bin/server.js
@@ -163,6 +163,8 @@ function getClient(clientToUseForMessage) {
     switch (clientToUseForMessage) {
         case 'bing':
             return new BingAIClient(settings.bingAiClient);
+        case 'sydney':
+            return new BingAIClient({ ...settings.bingAiClient, cache: settings.cacheOptions });
         case 'chatgpt-browser':
             return new ChatGPTBrowserClient(
                 settings.chatGptBrowserClient,

--- a/settings.example.js
+++ b/settings.example.js
@@ -1,9 +1,9 @@
 export default {
     // Options for the Keyv cache, see https://www.npmjs.com/package/keyv.
     // This is used for storing conversations, and supports additional drivers (conversations are stored in memory by default).
-    // Only applies when using `ChatGPTClient`.
+    // Only applies when using `ChatGPTClient` or `BingAIClient`.
     cacheOptions: {},
-    // If set, `ChatGPTClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
+    // If set, `ChatGPTClient` and `BingAIClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
     // However, `cacheOptions.store` will override this if set
     storageFilePath: process.env.STORAGE_FILE_PATH || './cache.json',
     chatGptClient: {
@@ -75,7 +75,7 @@ export default {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'sydney', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.

--- a/settings.example.js
+++ b/settings.example.js
@@ -1,7 +1,7 @@
 export default {
     // Options for the Keyv cache, see https://www.npmjs.com/package/keyv.
     // This is used for storing conversations, and supports additional drivers (conversations are stored in memory by default).
-    // Only applies when using `ChatGPTClient` or `BingAIClient`.
+    // Only necessary when using `ChatGPTClient`, or `BingAIClient` in jailbreak mode.
     cacheOptions: {},
     // If set, `ChatGPTClient` and `BingAIClient` will use `keyv-file` to store conversations to this JSON file instead of in memory.
     // However, `cacheOptions.store` will override this if set

--- a/settings.example.js
+++ b/settings.example.js
@@ -75,7 +75,7 @@ export default {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'sydney', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.


### PR DESCRIPTION
Since we were unable to use bing client to continue the conversation when we need to use sydney (cacheOptions wasn't set when invoking BingAIClient). I've added sydney client as a seperate option in settings.js