### PR TITLE
docs(readme): add halbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Instructions are provided below.
 - [PandoraAI](https://github.com/waylaidwanderer/PandoraAI): my web chat client powered by node-chatgpt-api, allowing users to easily chat with multiple AI systems while also offering support for custom presets. With its seamless and convenient design, PandoraAI provides an engaging conversational AI experience.
 - [ChatGPT Clone](https://github.com/danny-avila/chatgpt-clone): a clone of ChatGPT, uses official model, reverse-engineered UI, with AI model switching, message search, and prompt templates.
 - [ChatGPT WebApp](https://github.com/frontend-engineering/chatgpt-webapp-fullstack): a fullstack chat webapp with mobile compatble UI interface, and node-chatgpt-api works as backend. Anyone can deploy your own chat service.
+- [halbot](https://github.com/Leask/halbot): Just another ChatGPT/Bing Chat Telegram bob, which is simple design, easy to use, extendable and fun.
 
 Add yours to the list by [editing this README](https://github.com/waylaidwanderer/node-chatgpt-api/edit/main/README.md) and creating a pull request!
 

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Instructions are provided below.
 - [PandoraAI](https://github.com/waylaidwanderer/PandoraAI): my web chat client powered by node-chatgpt-api, allowing users to easily chat with multiple AI systems while also offering support for custom presets. With its seamless and convenient design, PandoraAI provides an engaging conversational AI experience.
 - [ChatGPT Clone](https://github.com/danny-avila/chatgpt-clone): a clone of ChatGPT, uses official model, reverse-engineered UI, with AI model switching, message search, and prompt templates.
 - [ChatGPT WebApp](https://github.com/frontend-engineering/chatgpt-webapp-fullstack): a fullstack chat webapp with mobile compatble UI interface, and node-chatgpt-api works as backend. Anyone can deploy your own chat service.
-- [halbot](https://github.com/Leask/halbot): Just another ChatGPT/Bing Chat Telegram bob, which is simple design, easy to use, extendable and fun.
+- [halbot](https://github.com/Leask/halbot): Just another ChatGPT/Bing Chat Telegram bot, which is simple design, easy to use, extendable and fun.
 
 Add yours to the list by [editing this README](https://github.com/waylaidwanderer/node-chatgpt-api/edit/main/README.md) and creating a pull request!
 


### PR DESCRIPTION
Adding my own project that using node-chatgpt-api.
My project is a telegram bot have these features:
- Telegram Bot (`Telegram Bot` token required)
- ChatGPT (`OpenAI` API key required)
- Bing Chat (`Bing Chat` user token required)
- Speech-to-text (`Google Cloud` API key required, or your own engine)
- Text-to-speech (`Google Cloud` API key required, or your own engine)
- Support `private` and `public` mode, with multiple authenticate methods.
- `Middleware` style workflow, easy to extend.
- Realtime stream-style response, no more waiting.
- Markdown rendering for GhatGPT
- Reference rendering for Bing Chat
- Code block rendering, developers friendly.
- ESM from the ground up