### PR TITLE
fix(bing): catch error events on WebSocket connection

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -77,13 +77,15 @@ export default class BingAIClient {
     }
 
     async createWebSocketConnection() {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             let agent;
             if (this.options.proxy) {
                 agent = new HttpsProxyAgent(this.options.proxy);
             }
 
             const ws = new WebSocket('wss://sydney.bing.com/sydney/ChatHub', { agent });
+
+            ws.on('error', err => reject(err);
 
             ws.on('open', () => {
                 if (this.debug) {

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -85,7 +85,7 @@ export default class BingAIClient {
 
             const ws = new WebSocket('wss://sydney.bing.com/sydney/ChatHub', { agent });
 
-            ws.on('error', err => reject(err);
+            ws.on('error', err => reject(err));
 
             ws.on('open', () => {
                 if (this.debug) {


### PR DESCRIPTION
Event handler on WebSocket for 'error' event needs to be set up a bit earlier.

node:events:368
      throw er; // Unhandled 'error' event
      ^

Error: Unexpected server response: 503
    at ClientRequest.<anonymous> (/node-chatgpt-api/node_modules/ws/lib/websocket.js:888:7)
    at ClientRequest.emit (node:events:390:28)
    at HTTPParser.parserOnIncomingClient (node:_http_client:623:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:128:17)
    at TLSSocket.socketOnData (node:_http_client:487:22)
    at TLSSocket.emit (node:events:390:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:199:23)
Emitted 'error' event on WebSocket instance at:
    at emitErrorAndClose (/node-chatgpt-api/node_modules/ws/lib/websocket.js:1008:13)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)