### PR TITLE
add  Paragraph output.

### DIFF
--- a/demos/use-client.js
+++ b/demos/use-client.js
@@ -79,4 +79,4 @@ response = await chatGptClient.sendMessage("Write a short poem about cats.", {
   onProgress,
 });
 console.log();
-console.log(response.response); // "Write a short poem about cats."
+console.log(response.response); 

--- a/demos/use-client.js
+++ b/demos/use-client.js
@@ -61,24 +61,22 @@ console.log(response.response); // Doux et élégant, avec des yeux qui brillent
 
 
 
-    //If you want to output faster (or avoid maximum message length) in some applications that cannot stream responses, you can do this. 
-  let receivedChars = "";
-  const onProgress = (token, done) => {
-    receivedChars += token;
-    if (
-      (receivedChars.length >= 150 && token == "\n") ||
-      receivedChars.length >= 500
-    ) {
-      console.log(receivedChars);
-      receivedChars = "";
-    } else if (done === true) {
-      console.log(receivedChars);
-    } 
-  };
-response = await chatGptClient.sendMessage('Repeat my 2nd message verbatim.', {
-    conversationId: response.conversationId,
-    parentMessageId: response.messageId,
-    onProgress
+//If you want to output faster (or avoid maximum message length) in some applications that cannot stream responses, you can do this.
+
+let receivedChars = "";
+const onProgress = (token, done) => {
+  receivedChars += token;
+  if (receivedChars.length >= 10) {
+    console.log(receivedChars);
+    receivedChars = "";
+  } else if (done === true) {
+    console.log(receivedChars);
+  }
+};
+response = await chatGptClient.sendMessage("Write a short poem about cats.", {
+  conversationId: response.conversationId,
+  parentMessageId: response.messageId,
+  onProgress,
 });
 console.log();
 console.log(response.response); // "Write a short poem about cats."

--- a/demos/use-client.js
+++ b/demos/use-client.js
@@ -62,6 +62,7 @@ console.log(response.response); // Doux et élégant, avec des yeux qui brillent
 
 
     //If you want to output faster (or avoid maximum message length) in some applications that cannot stream responses, you can do this. 
+  let receivedChars = "";
   const onProgress = (token, done) => {
     receivedChars += token;
     if (

--- a/demos/use-client.js
+++ b/demos/use-client.js
@@ -59,12 +59,25 @@ response = await chatGptClient.sendMessage('Now write it in French.', {
 console.log();
 console.log(response.response); // Doux et élégant, avec des yeux qui brillent,\nLes chats sont des créatures de grâce suprême.\n...
 
+
+
+    //If you want to output faster (or avoid maximum message length) in some applications that cannot stream responses, you can do this. 
+  const onProgress = (token, done) => {
+    receivedChars += token;
+    if (
+      (receivedChars.length >= 150 && token == "\n") ||
+      receivedChars.length >= 500
+    ) {
+      console.log(receivedChars);
+      receivedChars = "";
+    } else if (done === true) {
+      console.log(receivedChars);
+    } 
+  };
 response = await chatGptClient.sendMessage('Repeat my 2nd message verbatim.', {
     conversationId: response.conversationId,
     parentMessageId: response.messageId,
-    // If you want streamed responses, you can set the `onProgress` callback to receive the response as it's generated.
-    // You will receive one token at a time, so you will need to concatenate them yourself.
-    onProgress: token => process.stdout.write(token),
+    onProgress
 });
 console.log();
 console.log(response.response); // "Write a short poem about cats."

--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -341,6 +341,7 @@ ${botMessage.message}
                 payload,
                 (progressMessage) => {
                     if (progressMessage === '[DONE]') {
+                        opts.onProgress('',true);
                         return;
                     }
                     const token = this.isChatGptModel ? progressMessage.choices[0].delta.content : progressMessage.choices[0].text;
@@ -352,7 +353,6 @@ ${botMessage.message}
                         console.debug(token);
                     }
                     if (token === this.endToken) {
-                        opts.onProgress('',true);
                         return;
                     }
                     opts.onProgress(token);

--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -352,6 +352,7 @@ ${botMessage.message}
                         console.debug(token);
                     }
                     if (token === this.endToken) {
+                        opts.onProgress('',true);
                         return;
                     }
                     opts.onProgress(token);


### PR DESCRIPTION
In WeChat, if the number of words in the GPT reply is very long, the user will wait longer and cannot send more than 500 words, so this paragraph output is made to get the first message faster, and you can reply more long content