### PR TITLE
fix: update reverseProxyUrl in demo, raise awareness of duti.tech compromise

### DIFF
--- a/demos/use-browser-client.js
+++ b/demos/use-browser-client.js
@@ -4,7 +4,7 @@ import { ChatGPTBrowserClient } from '../index.js';
 const clientOptions = {
     // (Optional) Support for a reverse proxy for the completions endpoint (private API server).
     // Warning: This will expose your access token to a third party. Consider the risks before using this.
-    reverseProxyUrl: 'https://chatgpt.duti.tech/api/conversation',
+    reverseProxyUrl: 'https://bypass.churchless.tech/api/conversation',
     // Access token from https://chat.openai.com/api/auth/session
     accessToken: '',
     // Cookies from chat.openai.com (likely not required if using reverse proxy server).


### PR DESCRIPTION
According to @acheong08

> For anyone who hasn't upgraded revChatGPT, please do so immediately. My domain name, [http://duti.tech](https://t.co/MbI4ivSB7a), has expired and been taken over by an unknown entity.
> 
> There could be security issues if you do not upgrade such as token logging.
> 3:27 AM · Mar 31, 2023

source: https://twitter.com/GodlyIgnorance/status/1641703845767290880?cxt=HHwWgIDRleO8wMgtAAAA

I've provided the new public proxy used in [ChatGPT-Proxy-V4](https://github.com/acheong08/ChatGPT-Proxy-V4) that is confirmed working for the browser client