### PR TITLE
fix(bing): use empty string for real user message in jailbreak mode

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -315,7 +315,7 @@ export default class BingAIClient {
                     isStartOfSession: invocationId === 0,
                     message: {
                         author: 'user',
-                        text: jailbreakConversationId ? "" : message,
+                        text: jailbreakConversationId ? '' : message,
                         messageType: jailbreakConversationId ? 'SearchQuery' : 'Chat',
                     },
                     conversationSignature,

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -11,21 +11,6 @@ import HttpsProxyAgent from 'https-proxy-agent';
  */
 const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
 
-const insertRandomSeparator = (str) => {
-    // Split the string into an array of individual characters
-    const chars = str.split('');
-    // Use the map function to join each character together and randomly insert a separator or not
-    return chars.map((char, index) => {
-        // If not the first character, randomly decide whether to insert a separator based on a random number
-        if (index !== 0 && Math.random() >= 0.5) {
-            // Generate a random number and use a "-" as the separator if it is greater than or equal to 0.5, otherwise use "_"
-            const separator = Math.random() >= 0.5 ? '-' : '_';
-            return separator + char;
-        }
-        return char;
-    }).join('');
-};
-
 export default class BingAIClient {
     constructor(options) {
         const cacheOptions = options.cache || {};
@@ -330,7 +315,7 @@ export default class BingAIClient {
                     isStartOfSession: invocationId === 0,
                     message: {
                         author: 'user',
-                        text: jailbreakConversationId ? insertRandomSeparator(message) : message,
+                        text: jailbreakConversationId ? "" : message,
                         messageType: jailbreakConversationId ? 'SearchQuery' : 'Chat',
                     },
                     conversationSignature,


### PR DESCRIPTION
Hi everyone, really appreciate this project.

#264 fixed #263, but
- Now GPT-4 sees the message repeated twice: once in its normal form (in the `previousMessages` array) and once again in the garbled form with `-` and `_` inserted. This is understandably confusing, causing:
- GPT-4 to reject what looks like correct input to the user. For example, I modified the system message to play a chess game in ASCII art with the model (don't ask), and told it to reject incorrect moves. It would reject my moves many times in a row (since they looked like `Be-5`, `B_e5`, etc.)
- GPT-4 to think this is some new mode of communication, and modify its output accordingly (as demonstrated by @Naozumi520 in the comments of #264).

Dropping #264 in favor of the old "continue this conversation" prompt is problematic, of course. But a simpler solution is just to leave the message as an empty string. This gets the OK from Microsoft's API, and the model seems to have no problems with it (at least in my own testing). "Repeat my previous message" works flawlessly.

What do you guys think?