### PR TITLE
ChatGPTBrowserClient: Add generated title to response

### DIFF
--- a/demos/use-browser-client.js
+++ b/demos/use-browser-client.js
@@ -4,7 +4,7 @@ import { ChatGPTBrowserClient } from '../index.js';
 const clientOptions = {
     // (Optional) Support for a reverse proxy for the completions endpoint (private API server).
     // Warning: This will expose your access token to a third party. Consider the risks before using this.
-    reverseProxyUrl: 'https://chatgpt.duti.tech/api/conversation',
+    reverseProxyUrl: 'https://bypass.churchless.tech/api/conversation',
     // Access token from https://chat.openai.com/api/auth/session
     accessToken: '',
     // Cookies from chat.openai.com (likely not required if using reverse proxy server).

--- a/src/ChatGPTBrowserClient.js
+++ b/src/ChatGPTBrowserClient.js
@@ -167,7 +167,7 @@ export default class ChatGPTBrowserClient {
         });
 
         if (!conversationId) {
-            this.genTitle(response);
+            response.title = this.genTitle(response);
         }
 
         return response;
@@ -242,7 +242,7 @@ export default class ChatGPTBrowserClient {
         };
     }
 
-    genTitle(event) {
+    async genTitle(event) {
         const { debug } = this.options;
         if (debug) {
             console.log('Generate title: ', event);
@@ -278,11 +278,15 @@ export default class ChatGPTBrowserClient {
             console.debug(url, opts);
         }
 
-        fetch(url, opts).then(async (ret) => {
+        try {
+            const ret = await fetch(url, opts);
+            const data = await ret.text();
             if (debug) {
-                const data = await ret.text();
                 console.log('Gen title response: ', data);
             }
-        }).catch(console.error);
+            return JSON.parse(data).title;
+        } catch (error) {
+            console.error(error);
+        }
     }
 }


### PR DESCRIPTION
This is a simple proposed update but necessary for my app. 

This will add the officially generated title to the response object as a promise, which keeps the operation asynchronous and allows me to await `response.details.title` when I need it. Can be totally ignored by those who don't need it and should keep all other operations the same.

Thought this might be the simplest way to attach the title to a response, since it only generates on the first one.

Without this, I have to do a redundant call for a title since I know we make a request to the backend api. Not to mention, my own calls cost tokens (a few but they add up) and the official titling tends to perform better.