### PR TITLE
make genTitle method async and add to response object as promise

### DIFF
--- a/src/ChatGPTBrowserClient.js
+++ b/src/ChatGPTBrowserClient.js
@@ -167,7 +167,7 @@ export default class ChatGPTBrowserClient {
         });
 
         if (!conversationId) {
-            this.genTitle(response);
+            response.title = this.genTitle(response);
         }
 
         return response;
@@ -242,13 +242,13 @@ export default class ChatGPTBrowserClient {
         };
     }
 
-    genTitle(event) {
+    async genTitle(event) {
         const { debug } = this.options;
         if (debug) {
             console.log('Generate title: ', event);
         }
         if (!event || !event.conversation_id || !event.message || !event.message.id) {
-            return;
+            return null;
         }
 
         const conversationId = event.conversation_id;
@@ -278,11 +278,16 @@ export default class ChatGPTBrowserClient {
             console.debug(url, opts);
         }
 
-        fetch(url, opts).then(async (ret) => {
+        try {
+            const ret = await fetch(url, opts);
+            const data = await ret.text();
             if (debug) {
-                const data = await ret.text();
                 console.log('Gen title response: ', data);
             }
-        }).catch(console.error);
+            return JSON.parse(data).title;
+        } catch (error) {
+            console.error(error);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Test failing was a linter error (d'oh)

from #278: 

> This is a simple proposed update but necessary for my app.
> 
> This will add the officially generated title to the response object as a promise, which keeps the operation asynchronous and allows me to await response.details.title when I need it. Can be totally ignored by those who don't need it and should keep all other operations the same.
> 
> Thought this might be the simplest way to attach the title to a response, since it only generates on the first one.
> 
> Without this, I have to do a redundant call for a title since I know we make a request to the backend api. Not to mention, my own calls cost tokens (a few but they add up) and the official titling tends to perform better.
