### PR TITLE
feat(ChatGPTBrowserClient): add optional onEventMessage param for Browser Client

### DIFF
--- a/src/ChatGPTBrowserClient.js
+++ b/src/ChatGPTBrowserClient.js
@@ -29,7 +29,7 @@ export default class ChatGPTBrowserClient {
         this.model = this.options.model || 'text-davinci-002-render-sha';
     }
 
-    async postConversation(conversation, onProgress, abortController = null) {
+    async postConversation(conversation, onProgress, abortController, onEventMessage = null) {
         const {
             action = 'next',
             conversationId,
@@ -133,6 +133,11 @@ export default class ChatGPTBrowserClient {
                         if (debug) {
                             console.debug(eventMessage);
                         }
+
+                        if (onEventMessage) {
+                            onEventMessage(eventMessage);
+                        }
+
                         if (!eventMessage.data || eventMessage.event === 'ping') {
                             return;
                         }
@@ -212,6 +217,7 @@ export default class ChatGPTBrowserClient {
             },
             opts.onProgress || (() => {}),
             opts.abortController || new AbortController(),
+            opts?.onEventMessage,
         );
 
         if (this.options.debug) {


### PR DESCRIPTION
Adds an optional param to the postConversation method to handle event messages from the backend-api server, coming from sendMessage options.

I noticed while debugging that I could use the data being received during the stream from the backend-api. 

While having the tokens parsed for us is helpful for onProgress, this adds the benefit of receiving the additional data from the stream response. This PR simply adds a callback to process the data being streamed.

AbortController no longer has a default value of null as it no longer would be the last param, and a default value is being handled in L219.