### PR TITLE
feat(bing): take a Keyv object instead of options

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -15,13 +15,13 @@ export default class BingAIClient {
     constructor(options) {
         if (options.keyv) {
             if (!options.keyv.namespace) {
-                console.warn("The given Keyv object has no namespace. This is a bad idea if you share a database.");
+                console.warn('The given Keyv object has no namespace. This is a bad idea if you share a database.');
             }
             this.conversationsCache = options.keyv;
         } else {
             const cacheOptions = options.cache || {};
             cacheOptions.namespace = cacheOptions.namespace || 'bing';
-            this.conversationsCache = new Keyv(cacheOptions);   
+            this.conversationsCache = new Keyv(cacheOptions);
         }
 
         this.setOptions(options);

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -13,13 +13,16 @@ const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 
 
 export default class BingAIClient {
     constructor(options) {
-        if (options.cache) {
-            if (!options.cache.namespace) {
-                console.warn("The given Keyv object has no namespace. This is a bad idea if you share a database.")   
+        if (options.keyv) {
+            if (!options.keyv.namespace) {
+                console.warn("The given Keyv object has no namespace. This is a bad idea if you share a database.");
             }
+            this.conversationsCache = options.keyv;
+        } else {
+            const cacheOptions = options.cache || {};
+            cacheOptions.namespace = cacheOptions.namespace || 'bing';
+            this.conversationsCache = new Keyv(cacheOptions);   
         }
-        
-        this.conversationsCache = options.cache || new Keyv()
 
         this.setOptions(options);
     }

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -13,9 +13,13 @@ const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 
 
 export default class BingAIClient {
     constructor(options) {
-        const cacheOptions = options.cache || {};
-        cacheOptions.namespace = cacheOptions.namespace || 'bing';
-        this.conversationsCache = new Keyv(cacheOptions);
+        if (options.cache) {
+            if (!options.cache.namespace) {
+                console.warn("The given Keyv object has no namespace. This is a bad idea if you share a database.")   
+            }
+        }
+        
+        this.conversationsCache = options.cache || new Keyv()
 
         this.setOptions(options);
     }


### PR DESCRIPTION
Instead of taking Keyv options (which I had serious troubles with), just take a Keyv object. It's simpler for new Keyv users and is way more intuitive: Just pass your Keyv object as "cache" in the JSON object and do whatever while making it.