### PR TITLE
Fix keeping repeating introduction due to empty message string + use a more native method to pass web page context

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -236,10 +236,6 @@ export default class BingAIClient {
                     author: 'system',
                 },
                 ...previousCachedMessages,
-                {
-                    text: message,
-                    author: 'user',
-                },
             ] : undefined;
 
             if (context) {
@@ -259,7 +255,7 @@ export default class BingAIClient {
                     case 'system':
                         return `N/A\n\n[system](#additional_instructions)\n- ${previousMessage.text}`;
                     case 'context':
-                        return `[user](#context)\n${previousMessage.text}`;
+                        return `[system](#context)\nWeb page context:\n\`\`\`\n${previousMessage.text}\n\`\`\``;
                     default:
                         throw new Error(`Unknown message author: ${previousMessage.author}`);
                 }
@@ -312,6 +308,7 @@ export default class BingAIClient {
                         'cricinfo',
                         'cricinfov2',
                         'dv3sugg',
+                        'nojbfedge',
                     ],
                     sliceIds: [
                         '222dtappid',
@@ -322,7 +319,7 @@ export default class BingAIClient {
                     isStartOfSession: invocationId === 0,
                     message: {
                         author: 'user',
-                        text: jailbreakConversationId ? '' : message,
+                        text: message,
                         messageType: jailbreakConversationId ? 'SearchQuery' : 'Chat',
                     },
                     conversationSignature,

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -236,6 +236,11 @@ export default class BingAIClient {
                     author: 'system',
                 },
                 ...previousCachedMessages,
+                // We still need this to avoid repeating introduction in some cases
+                {
+                    text: message,
+                    author: 'user',
+                },
             ] : undefined;
 
             // prepare messages for prompt injection

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -246,14 +246,14 @@ export default class BingAIClient {
                     case 'bot':
                         return `[assistant](#message)\n${previousMessage.text}`;
                     case 'system':
-                        return `N/A\n\n[system](#additional_instructions)\n- ${previousMessage.text}`;
+                        return `[system](#additional_instructions)\n${previousMessage.text}`;
                     default:
                         throw new Error(`Unknown message author: ${previousMessage.author}`);
                 }
             }).join('\n\n');
 
             if (context) {
-                previousMessagesFormatted = context + previousMessagesFormatted;
+                previousMessagesFormatted = `${context}\n\n${previousMessagesFormatted}`;
             }
         }
 

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -238,13 +238,6 @@ export default class BingAIClient {
                 ...previousCachedMessages,
             ] : undefined;
 
-            if (context) {
-                previousMessages.push({
-                    text: context,
-                    author: 'context', // not a real/valid author, we're just piggybacking on the existing logic
-                });
-            }
-
             // prepare messages for prompt injection
             previousMessagesFormatted = previousMessages?.map((previousMessage) => {
                 switch (previousMessage.author) {
@@ -254,12 +247,14 @@ export default class BingAIClient {
                         return `[assistant](#message)\n${previousMessage.text}`;
                     case 'system':
                         return `N/A\n\n[system](#additional_instructions)\n- ${previousMessage.text}`;
-                    case 'context':
-                        return `[system](#context)\nWeb page context:\n\`\`\`\n${previousMessage.text}\n\`\`\``;
                     default:
                         throw new Error(`Unknown message author: ${previousMessage.author}`);
                 }
             }).join('\n\n');
+
+            if (context) {
+                previousMessagesFormatted = context + previousMessagesFormatted;
+            }
         }
 
         const userMessage = {


### PR DESCRIPTION
fixes https://github.com/waylaidwanderer/node-chatgpt-api/issues/289 and https://github.com/waylaidwanderer/node-chatgpt-api/issues/330
have tested https://github.com/waylaidwanderer/node-chatgpt-api/pull/216#issuecomment-1480616340