### PR TITLE
feat(ChatGPTClient.js): add support for Azure by API key

### DIFF
--- a/demos/use-client.js
+++ b/demos/use-client.js
@@ -8,6 +8,9 @@ const clientOptions = {
     // Warning: This will expose your `openaiApiKey` to a third party. Consider the risks before using this.
     // reverseProxyUrl: 'https://chatgpt.hato.ai/completions',
     // (Optional) Parameters as described in https://platform.openai.com/docs/api-reference/completions
+    // (Optional) to use Azure OpenAI API, set `azure` to true and `reverseProxyUrl` to your completion endpoint:
+    // azure: true,
+    // reverseProxyUrl: 'https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}',
     modelOptions: {
         // You can override the model name and any other parameters here, like so:
         model: 'gpt-3.5-turbo',

--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -170,7 +170,10 @@ export default class ChatGPTClient {
                 headersTimeout: 0,
             }),
         };
-        if (this.apiKey) {
+
+        if (this.apiKey && this.options.azure && this.options.reverseProxyUrl) {
+            opts.headers['api-key'] = this.apiKey;
+        } else if (this.apiKey) {
             opts.headers.Authorization = `Bearer ${this.apiKey}`;
         }
 


### PR DESCRIPTION
I was given access to Azure OpenAI and I noticed that changing the reverse proxy URL and providing the API key as mentioned in #192 would not work for me. 

The reason was that authentication is done through the 'api-key' header and not Authorization Bearer. You can authenticate an API call using an Azure Active Directory token with Auth Bearer, but as I'm not an owner of the Azure account, auth by api key is my only option. This was not clear in the repo before, and this would make it standard to authenticate by API key as shown in their docs: https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference

As shown in `demos/use-client.js`, to use Azure OpenAI API with ChatGPTClient, set `azure` to true and `reverseProxyUrl` to your completion endpoint in clientOptions, providing your Azure OpenAI API Key as the first arg as usual:
```
azure: true,
reverseProxyUrl: 'https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}',
```