### PR TITLE
fix(bing): extend message timeout

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -368,7 +368,7 @@ export default class BingAIClient {
             const messageTimeout = setTimeout(() => {
                 this.constructor.cleanupWebSocketConnection(ws);
                 reject(new Error('Timed out waiting for response. Try enabling debug mode to see more information.'));
-            }, 120 * 1000);
+            }, 180 * 1000);
 
             // abort the request if the abort controller is aborted
             abortController.signal.addEventListener('abort', () => {


### PR DESCRIPTION
Bing is able to output very long messages for almost 3 minutes before ending it's answer.

Having the 2 min timout prevent the user from being able to get any long answer from Bing/Sydney. 

Pushing it to 3min (180 sec) is enough for the longest possible answer as of now.