### PR TITLE
feat(client): add support for custom headers in options object

### DIFF
--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -177,6 +177,10 @@ export default class ChatGPTClient {
             opts.headers.Authorization = `Bearer ${this.apiKey}`;
         }
 
+        if (this.options.headers) {
+            opts.headers = { ...opts.headers, ...this.options.headers };
+        }
+
         if (this.options.proxy) {
             opts.dispatcher = new ProxyAgent(this.options.proxy);
         }


### PR DESCRIPTION
Title. I have a need to set the Org ID, which is set in the headers:

```
curl https://api.openai.com/v1/models \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "OpenAI-Organization: YOUR_ORG_ID"
```

This way I can add the org ID or any other header if ever needed in the future
```
// options.header object
{
    'OpenAI-Organization': `${myOrgId}`
}
```