### PR TITLE
feat(bing): add the image generation function

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,6 +40,10 @@ if (settings.storageFilePath && !settings.cacheOptions.store) {
     settings.cacheOptions.store = new KeyvFile({ filename: settings.storageFilePath });
 }
 
+// Disable the image generation in cli mode always.
+settings.bingAiClient.features = settings.bingAiClient.features || {};
+settings.bingAiClient.features.genImage = false;
+
 let conversationData = {};
 
 const availableCommands = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dqbd/tiktoken": "^1.0.2",
         "@fastify/cors": "^8.2.0",
+        "@timefox/bic-sydney": "^1.1.2",
         "@waylaidwanderer/fastify-sse-v2": "^3.1.0",
         "@waylaidwanderer/fetch-event-source": "^3.0.1",
         "boxen": "^7.0.1",
@@ -243,6 +244,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@timefox/bic-sydney": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@timefox/bic-sydney/-/bic-sydney-1.1.2.tgz",
+      "integrity": "sha512-snh+xWn7kuYbkCs2SMBZD0vx5rDjNANZKAEiSB1tDxudVU7CjjvK7009hQP0nwR/f57y2yHdsg7jQOjz7SL5SA==",
+      "dependencies": {
+        "fetch-undici": "^3.0.1",
+        "undici": "^5.22.1"
       }
     },
     "node_modules/@types/json5": {
@@ -4457,6 +4467,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@timefox/bic-sydney": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@timefox/bic-sydney/-/bic-sydney-1.1.2.tgz",
+      "integrity": "sha512-snh+xWn7kuYbkCs2SMBZD0vx5rDjNANZKAEiSB1tDxudVU7CjjvK7009hQP0nwR/f57y2yHdsg7jQOjz7SL5SA==",
+      "requires": {
+        "fetch-undici": "^3.0.1",
+        "undici": "^5.22.1"
       }
     },
     "@types/json5": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.2",
     "@fastify/cors": "^8.2.0",
+    "@timefox/bic-sydney": "^1.1.2",
     "@waylaidwanderer/fastify-sse-v2": "^3.1.0",
     "@waylaidwanderer/fetch-event-source": "^3.0.1",
     "boxen": "^7.0.1",

--- a/settings.example.js
+++ b/settings.example.js
@@ -46,6 +46,13 @@ export default {
         cookies: '',
         // A proxy string like "http://<ip>:<port>"
         proxy: '',
+        // (Optional) Set 'x-forwarded-for' for the request. You can use a fixed IPv4 address or specify a range using CIDR notation,
+        // and the program will randomly select an address within that range. The 'x-forwarded-for' is not used by default now.
+        // xForwardedFor: '13.104.0.0/14',
+        // (Optional) Set 'genImage' to true to enable bing to create images for you. It's disabled by default.
+        // features: {
+        //     genImage: true,
+        // },
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
     },

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -512,14 +512,15 @@ export default class BingAIClient {
                             eventMessage.text = replySoFar;
                             // delete useless suggestions from moderation filter
                             delete eventMessage.suggestedResponses;
-                        } else {
+                        }                      
+                        if (bicIframe) {
+                            // the last messages will be a image creation event if bicIframe is present.
                             let i = messages.length - 1;
                             while (eventMessage?.contentType === 'IMAGE' && i > 0) {
                                 eventMessage = messages[i -= 1];
                             }
-                        }
-                        if (bicIframe) {
-                            // if bicIframe is presented, wait for it to be completed.
+
+                            // wait for bicIframe to be completed.
                             bicIframe.then(async (result) => {
                                 // The frame can be large, only put it into adaptiveCards.
                                 eventMessage.adaptiveCards[0].body[0].text += result;

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -521,7 +521,7 @@ export default class BingAIClient {
                             while (eventMessage?.contentType === 'IMAGE' && i > 0) {
                                 eventMessage = messages[i -= 1];
                             }
-                            
+
                             // wait for bicIframe to be completed.
                             bicIframe.then((result) => {
                                 // The frame can be large, only put it into adaptiveCards.

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -443,7 +443,11 @@ export default class BingAIClient {
                                 messages[0].text,
                                 messages[0].messageId,
                                 progress => (progress?.contentIframe ? onProgress(progress?.contentIframe) : null),
-                            );
+                            ).catch((error) => {
+                                onProgress(error.message);
+                                bicIframe.isError = true;
+                                return error.message;
+                            });
                             return;
                         }
                         const updatedText = messages[0].text;
@@ -523,11 +527,12 @@ export default class BingAIClient {
                             }
 
                             // wait for bicIframe to be completed.
-                            try {
-                                const imgIframe = await bicIframe;
+                            // since we added a catch, we do not need to wrap this with a try catch block.
+                            const imgIframe = await bicIframe;
+                            if (!imgIframe?.isError) {
                                 eventMessage.adaptiveCards[0].body[0].text += imgIframe;
-                            } catch (error) {
-                                eventMessage.text += `<br>${error}`;
+                            } else {
+                                eventMessage.text += `<br>${imgIframe}`;
                                 eventMessage.adaptiveCards[0].body[0].text = eventMessage.text;
                             }
                         }

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -530,17 +530,11 @@ export default class BingAIClient {
                                 eventMessage.text += `<br>${error}`;
                                 eventMessage.adaptiveCards[0].body[0].text = eventMessage.text;
                             }
-                            resolve({
-                                message: eventMessage,
-                                conversationExpiryTime: event?.item?.conversationExpiryTime,
-                            });
-                        } else {
-                            // if there is no bicIframe, we resolve it normally.
-                            resolve({
-                                message: eventMessage,
-                                conversationExpiryTime: event?.item?.conversationExpiryTime,
-                            });
                         }
+                        resolve({
+                            message: eventMessage,
+                            conversationExpiryTime: event?.item?.conversationExpiryTime,
+                        });
                         // eslint-disable-next-line no-useless-return
                         return;
                     }

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -512,7 +512,7 @@ export default class BingAIClient {
                             eventMessage.text = replySoFar;
                             // delete useless suggestions from moderation filter
                             delete eventMessage.suggestedResponses;
-                        }                      
+                        }
                         if (bicIframe) {
                             // the last messages will be a image creation event if bicIframe is present.
                             let i = messages.length - 1;

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -4,6 +4,7 @@ import WebSocket from 'ws';
 import Keyv from 'keyv';
 import { ProxyAgent } from 'undici';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { BingImageCreator } from '@timefox/bic-sydney';
 
 /**
  * https://stackoverflow.com/a/58326357
@@ -39,9 +40,40 @@ export default class BingAIClient {
             this.options = {
                 ...options,
                 host: options.host || 'https://www.bing.com',
+                xForwardedFor: this.constructor.getValidIPv4(options.xForwardedFor),
+                features: {
+                    genImage: options?.features?.genImage || false,
+                },
             };
         }
         this.debug = this.options.debug;
+        if (this.options.features.genImage) {
+            this.bic = new BingImageCreator(this.options);
+        }
+    }
+
+    static getValidIPv4(ip) {
+        const match = !ip
+            || ip.match(/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\/([0-9]|[1-2][0-9]|3[0-2]))?$/);
+        if (match) {
+            if (match[5]) {
+                const mask = parseInt(match[5], 10);
+                let [a, b, c, d] = ip.split('.').map(x => parseInt(x, 10));
+                // eslint-disable-next-line no-bitwise
+                const max = (1 << (32 - mask)) - 1;
+                const rand = Math.floor(Math.random() * max);
+                d += rand;
+                c += Math.floor(d / 256);
+                d %= 256;
+                b += Math.floor(c / 256);
+                c %= 256;
+                a += Math.floor(b / 256);
+                b %= 256;
+                return `${a}.${b}.${c}.${d}`;
+            }
+            return ip;
+        }
+        return undefined;
     }
 
     async createNewConversation() {
@@ -50,11 +82,11 @@ export default class BingAIClient {
                 accept: 'application/json',
                 'accept-language': 'en-US,en;q=0.9',
                 'content-type': 'application/json',
-                'sec-ch-ua': '"Chromium";v="112", "Microsoft Edge";v="112", "Not:A-Brand";v="99"',
+                'sec-ch-ua': '"Microsoft Edge";v="113", "Chromium";v="113", "Not-A.Brand";v="24"',
                 'sec-ch-ua-arch': '"x86"',
                 'sec-ch-ua-bitness': '"64"',
-                'sec-ch-ua-full-version': '"112.0.1722.7"',
-                'sec-ch-ua-full-version-list': '"Chromium";v="112.0.5615.20", "Microsoft Edge";v="112.0.1722.7", "Not:A-Brand";v="99.0.0.0"',
+                'sec-ch-ua-full-version': '"113.0.1774.50"',
+                'sec-ch-ua-full-version-list': '"Microsoft Edge";v="113.0.1774.50", "Chromium";v="113.0.5672.127", "Not-A.Brand";v="24.0.0.0"',
                 'sec-ch-ua-mobile': '?0',
                 'sec-ch-ua-model': '""',
                 'sec-ch-ua-platform': '"Windows"',
@@ -64,11 +96,13 @@ export default class BingAIClient {
                 'sec-fetch-site': 'same-origin',
                 'x-ms-client-request-id': crypto.randomUUID(),
                 'x-ms-useragent': 'azsdk-js-api-client-factory/1.0.0-beta.1 core-rest-pipeline/1.10.0 OS/Win32',
-                cookie: this.options.cookies || (this.options.userToken ? `_U=${this.options.userToken}` : undefined),
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.50',
+                cookie: this.options.cookies || `_U=${this.options.userToken}`,
                 Referer: 'https://www.bing.com/search?q=Bing+AI&showconv=1&FORM=hpcodx',
                 'Referrer-Policy': 'origin-when-cross-origin',
                 // Workaround for request being blocked due to geolocation
-                'x-forwarded-for': '1.1.1.1',
+                // 'x-forwarded-for': '1.1.1.1', // 1.1.1.1 seems to no longer work.
+                ...(this.xForwardedFor ? { 'x-forwarded-for': this.xForwardedFor } : {}),
             },
         };
         if (this.options.proxy) {
@@ -309,6 +343,7 @@ export default class BingAIClient {
                         'cricinfov2',
                         'dv3sugg',
                         'nojbfedge',
+                        ...((toneStyle === 'creative' && this.options.features.genImage) ? ['gencontentv3'] : []),
                     ],
                     sliceIds: [
                         '222dtappid',
@@ -377,6 +412,7 @@ export default class BingAIClient {
                 reject(new Error('Request aborted'));
             });
 
+            let bicIframe;
             ws.on('message', (data) => {
                 const objects = data.toString().split('');
                 const events = objects.map((object) => {
@@ -397,6 +433,15 @@ export default class BingAIClient {
                         }
                         const messages = event?.arguments?.[0]?.messages;
                         if (!messages?.length || messages[0].author !== 'bot') {
+                            return;
+                        }
+                        if (messages[0]?.contentType === 'IMAGE') {
+                            // You will never get a message of this type without 'gencontentv3' being on.
+                            bicIframe = this.bic.genImageIframeSsr(
+                                messages[0].text,
+                                messages[0].messageId,
+                                progress => (progress?.contentIframe ? onProgress(progress?.contentIframe) : null),
+                            );
                             return;
                         }
                         const updatedText = messages[0].text;
@@ -423,7 +468,7 @@ export default class BingAIClient {
                             return;
                         }
                         const messages = event.item?.messages || [];
-                        const eventMessage = messages.length ? messages[messages.length - 1] : null;
+                        let eventMessage = messages.length ? messages[messages.length - 1] : null;
                         if (event.item?.result?.error) {
                             if (this.debug) {
                                 console.debug(event.item.result.value, event.item.result.message);
@@ -467,11 +512,36 @@ export default class BingAIClient {
                             eventMessage.text = replySoFar;
                             // delete useless suggestions from moderation filter
                             delete eventMessage.suggestedResponses;
+                        } else {
+                            let i = messages.length - 1;
+                            while (eventMessage?.contentType === 'IMAGE' && i > 0) {
+                                eventMessage = messages[i -= 1];
+                            }
                         }
-                        resolve({
-                            message: eventMessage,
-                            conversationExpiryTime: event?.item?.conversationExpiryTime,
-                        });
+                        if (bicIframe) {
+                            // if bicIframe is presented, wait for it to be completed.
+                            bicIframe.then(async (result) => {
+                                // The frame can be large, only put it into adaptiveCards.
+                                eventMessage.adaptiveCards[0].body[0].text += result;
+                                resolve({
+                                    message: eventMessage,
+                                    conversationExpiryTime: event?.item?.conversationExpiryTime,
+                                });
+                            }).catch((error) => {
+                                eventMessage.text += `<br>${error}`;
+                                eventMessage.adaptiveCards[0].body[0].text = eventMessage.text;
+                                resolve({
+                                    message: eventMessage,
+                                    conversationExpiryTime: event?.item?.conversationExpiryTime,
+                                });
+                            });
+                        } else {
+                            // if there is no bicIframe, we resolve it normally.
+                            resolve({
+                                message: eventMessage,
+                                conversationExpiryTime: event?.item?.conversationExpiryTime,
+                            });
+                        }
                         // eslint-disable-next-line no-useless-return
                         return;
                     }
@@ -484,6 +554,11 @@ export default class BingAIClient {
                         return;
                     }
                     default:
+                        if (event?.error) {
+                            clearTimeout(messageTimeout);
+                            this.constructor.cleanupWebSocketConnection(ws);
+                            reject(new Error(`Event Type('${event.type}'): ${event.error}`));
+                        }
                         // eslint-disable-next-line no-useless-return
                         return;
                 }

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -97,12 +97,12 @@ export default class BingAIClient {
                 'x-ms-client-request-id': crypto.randomUUID(),
                 'x-ms-useragent': 'azsdk-js-api-client-factory/1.0.0-beta.1 core-rest-pipeline/1.10.0 OS/Win32',
                 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.50',
-                cookie: this.options.cookies || `_U=${this.options.userToken}`,
+                cookie: this.options.cookies || (this.options.userToken ? `_U=${this.options.userToken}` : undefined),
                 Referer: 'https://www.bing.com/search?q=Bing+AI&showconv=1&FORM=hpcodx',
                 'Referrer-Policy': 'origin-when-cross-origin',
                 // Workaround for request being blocked due to geolocation
                 // 'x-forwarded-for': '1.1.1.1', // 1.1.1.1 seems to no longer work.
-                ...(this.xForwardedFor ? { 'x-forwarded-for': this.xForwardedFor } : {}),
+                ...(this.xForwardedFor ? { 'x-forwarded-for': this.options.xForwardedFor } : {}),
             },
         };
         if (this.options.proxy) {
@@ -519,9 +519,9 @@ export default class BingAIClient {
                             while (eventMessage?.contentType === 'IMAGE' && i > 0) {
                                 eventMessage = messages[i -= 1];
                             }
-
+                            
                             // wait for bicIframe to be completed.
-                            bicIframe.then(async (result) => {
+                            bicIframe.then((result) => {
                                 // The frame can be large, only put it into adaptiveCards.
                                 eventMessage.adaptiveCards[0].body[0].text += result;
                                 resolve({

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -102,7 +102,6 @@ export default class BingAIClient {
                 cookie: this.options.cookies || (this.options.userToken ? `_U=${this.options.userToken}` : undefined),
                 Referer: 'https://www.bing.com/search?q=Bing+AI&showconv=1',
                 'Referrer-Policy': 'origin-when-cross-origin',
-                cookie: this.options.cookies || (this.options.userToken ? `_U=${this.options.userToken}` : undefined),
                 // Workaround for request being blocked due to geolocation
                 // 'x-forwarded-for': '1.1.1.1', // 1.1.1.1 seems to no longer work.
                 ...(this.xForwardedFor ? { 'x-forwarded-for': this.options.xForwardedFor } : {}),


### PR DESCRIPTION
1.Import a new module '[@timefox/bic-sydney](https://github.com/timefox/node-bic-sydney)' to complete the main work of image generation for bingAiClient. The main procedure is to send the prompt returned by bing ai to bing image creator to generate the images, and then return an iframe containing the generated images.
2.Add an option to to turn on/off the image generation function of bingAiClient under 'bingAiClient/features/genImage', and disable it by default. For cli mode, it is set to false forcely.
3.Add an option to to set bingAiClient's 'x-forwarded-for' IP under 'bingAiClient/xForwardedFor'. It can be fixed, or a rand IP in a range using CIDR notation, or none. The default value is 'none'.