### PR TITLE
refactor(ChatGPTClient): improve token/tokenizer handling and return promptTokens

### DIFF
--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -111,7 +111,7 @@ export default class ChatGPTClient {
             this.endToken = '';
         }
     }
-    
+
     setupTokenizer() {
         this.encoding = 'text-davinci-003';
         if (this.isChatGptModel) {
@@ -131,7 +131,6 @@ export default class ChatGPTClient {
             }
         }
     }
-    
 
     static getTokenizer(encoding, isModelName = false, extendSpecialTokens = {}) {
         if (tokenizersCache[encoding]) {
@@ -428,6 +427,11 @@ ${botMessage.message}
             returnData.title = conversation.title;
         }
 
+        // if stream is true, we should add the prompt tokens to return data
+        if (typeof opts.onProgress === 'function') {
+            returnData.promptTokens = this.promptTokens;
+        }
+
         await this.conversationsCache.set(conversationId, conversation);
 
         if (this.options.returnConversation) {
@@ -529,6 +533,7 @@ ${botMessage.message}
 
         // Use up to `this.maxContextTokens` tokens (prompt + response), but try to leave `this.maxTokens` tokens for the response.
         this.modelOptions.max_tokens = Math.min(this.maxContextTokens - currentTokenCount, this.maxResponseTokens);
+        this.promptTokens = currentTokenCount;
 
         if (isChatGptModel) {
             return { prompt: [instructionsPayload, messagePayload], context };


### PR DESCRIPTION
This PR should address the problem in #259 as any encoding errors will be caught. The encoder/tokenizer will then be freed and reinitialized.

The catch logic has been tested by intentionally throwing errors with every getTokenCount call, and is successful every time.

---

⚠️ **Still todo: reduce the amount of getTokenCount calls.** An initial message calls getTokenCount 6 times, and every additional message increases the calls by 2 per request. Encoding the tokens can be exhaustive on resources and this should be handled to improve scalability. Issue #259 may resurface if the problem arises when too much encoding happens at once, whether by too many sendMessage calls, message counts, or both. 

The token count per message should be cached to avoid this. Aside from that and reducing the sendMessage calls, we could free up the tokenizer after every sendMessage request with the same catch logic in getTokenCount.

---

I also took this opportunity to assign promptTokens to the client, and include it in returnData. 
```javascript
{
 // ...returnData,
  promptTokens: 121, // the last currentTokenCount value from buildPrompt method
}
```

Figuring out exactly how many tokens were sent to the API would involve repeating the code of the client, since it is handling prompts in a specific way. This is particularly relevant when streaming responses and/or aborting a message. In my case, I'm trying to count token usage accurately. 

Note the discrepancies: 
 **initial message**
```
// returnData from client
  promptTokens: 136, 
// my attempt to count the tokens myself 
prompt_tokens: 94
```
**follow-up message**
```
  promptTokens: 173,
prompt_tokens: 17
```
**OpenAI usage:**
```
gpt-4-0314, 2 requests
311 prompt tokens
```

Without the promptTokens from client, I would have to repeat the prompt building logic to more accurately estimate usage (the total returned by client is only off by 2)