### PR TITLE
hotfix(bing): remove IP ban check (no longer working)

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -113,9 +113,12 @@ export default class BingAIClient {
         const response = await fetch(`${this.options.host}/turing/conversation/create`, fetchOptions);
 
         const { status, headers } = response;
-        if (status === 200 && +headers.get('content-length') < 5) {
+        
+        // This check no longer works. TODO: Reimplement this check.
+        
+        /*if (status === 200 && +headers.get('content-length') < 5) {
             throw new Error('/turing/conversation/create: Your IP is blocked by BingAI.');
-        }
+        }*/
 
         const body = await response.text();
         try {

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -111,15 +111,6 @@ export default class BingAIClient {
             fetchOptions.dispatcher = new ProxyAgent(this.options.proxy);
         }
         const response = await fetch(`${this.options.host}/turing/conversation/create`, fetchOptions);
-
-        const { status, headers } = response;
-        
-        // This check no longer works. TODO: Reimplement this check.
-        
-        /*if (status === 200 && +headers.get('content-length') < 5) {
-            throw new Error('/turing/conversation/create: Your IP is blocked by BingAI.');
-        }*/
-
         const body = await response.text();
         try {
             return JSON.parse(body);


### PR DESCRIPTION
The ban check seems to no longer work (The Content-Length header is no longer added for the request when doing it from this module). Checked on Deno.

It might be wise to check the length of the response as text instead of Content-Length- that way MS can't just remove the header.