### PR TITLE
fix(bing): increase timeout to prevent timeout error

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -2,7 +2,7 @@ import './fetch-polyfill.js';
 import crypto from 'crypto';
 import WebSocket from 'ws';
 import Keyv from 'keyv';
-import { ProxyAgent } from 'undici';
+import { Agent, ProxyAgent } from 'undici';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { BingImageCreator } from '@timefox/bic-sydney';
 
@@ -113,6 +113,8 @@ export default class BingAIClient {
         };
         if (this.options.proxy) {
             fetchOptions.dispatcher = new ProxyAgent(this.options.proxy);
+        } else {
+            fetchOptions.dispatcher = new Agent({ connect: { timeout: 20_000 } });
         }
         const response = await fetch(`${this.options.host}/turing/conversation/create`, fetchOptions);
         const body = await response.text();


### PR DESCRIPTION
Increase the timeout for the Web Socket from a default of 5 seconds to 20 seconds.
The error will only really occur on peak times, but this fix will prevent any timeout error.
Will fix errors mentioned in #328 and #338.