### PR TITLE
Update README for LibreChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Instructions are provided below.
 ## Projects
 🚀 A list of awesome projects using `@waylaidwanderer/chatgpt-api`:
 - [PandoraAI](https://github.com/waylaidwanderer/PandoraAI): my web chat client powered by node-chatgpt-api, allowing users to easily chat with multiple AI systems while also offering support for custom presets. With its seamless and convenient design, PandoraAI provides an engaging conversational AI experience.
-- [ChatGPT Clone](https://github.com/danny-avila/chatgpt-clone): a clone of ChatGPT, uses official model, reverse-engineered UI, with AI model switching, message search, and prompt templates.
+- [LibreChat](https://github.com/danny-avila/chatgpt-clone): integrates ChatGPT technology, enabling multiple AI models, conversation features, message search, and plugins. It offers free/pay-per-call APIs, eliminating ChatGPT Plus need, and supports customization.
 - [ChatGPT WebApp](https://github.com/frontend-engineering/chatgpt-webapp-fullstack): a fullstack chat webapp with mobile compatble UI interface, and node-chatgpt-api works as backend. Anyone can deploy your own chat service.
 - [halbot](https://github.com/Leask/halbot): Just another ChatGPT/Bing Chat Telegram bot, which is simple design, easy to use, extendable and fun.
 - [ChatGPTBox](https://github.com/josStorer/chatGPTBox): Integrating ChatGPT into your browser deeply, everything you need is here


### PR DESCRIPTION
## update readme for LibreChat

I have updated the README.md since ChatGPT Clone is now called [LibreChat](https://github.com/danny-avila/LibreChat)