### PR TITLE
fix(bing): restore filter bypass

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -435,6 +435,9 @@ export default class BingAIClient {
                         if (!messages?.length || messages[0].author !== 'bot') {
                             return;
                         }
+                        if (messages[0].contentOrigin === 'Apology') {
+                            return;
+                        }
                         if (messages[0]?.contentType === 'IMAGE') {
                             // You will never get a message of this type without 'gencontentv3' being on.
                             bicIframe = this.bic.genImageIframeSsr(


### PR DESCRIPTION
Restore the existing filter bypass, since it was not working properly for some weeks and the apology replaced the generated text.
I did some testing and apparently it's enough to check for the contentOrigin at this time.
Please let me know if that changes or it's not working for anyone.
Related issue #456.