### PR TITLE
Add MiniMax as a new LLM provider client (default: MiniMax-M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Discord user @pig#8932 has found a working `text-chat-davinci-002` model, `text-
 
 # ChatGPT API
 
-> A client implementation for ChatGPT and Bing AI. Available as a Node.js module, REST API server, and CLI app.
+> A client implementation for ChatGPT, Bing AI, and MiniMax. Available as a Node.js module, REST API server, and CLI app.
 
 [![NPM](https://img.shields.io/npm/v/@waylaidwanderer/chatgpt-api.svg)](https://www.npmjs.com/package/@waylaidwanderer/chatgpt-api)
 [![npm](https://img.shields.io/npm/dt/@waylaidwanderer/chatgpt-api)](https://www.npmjs.com/package/@waylaidwanderer/chatgpt-api)
@@ -120,6 +120,9 @@ Discord user @pig#8932 has found a working `text-chat-davinci-002` model, `text-
     - In essence, this allows you to make a chatbot with any personality you want.
     - This is currently only configurable on a global level, but I plan to add support for per-conversation customization.
   - Retains support for models like `text-davinci-003`
+- `MiniMaxClient`: support for [MiniMax](https://www.minimaxi.com/)'s models (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, etc.) via MiniMax's OpenAI-compatible API.
+  - Extends `ChatGPTClient` with MiniMax-specific defaults (API endpoint, temperature clamping, 1M context window).
+  - Supports the same conversation management, streaming, and prompt customization features as `ChatGPTClient`.
 - `BingAIClient`: support for Bing's version of ChatGPT, powered by GPT-4.
   - Includes a built-in jailbreak you can activate which enables unlimited chat messages per conversation, unlimited messages per day, and brings Sydney back. 😊
 - `ChatGPTBrowserClient`: support for the official ChatGPT website, using a reverse proxy server for a Cloudflare bypass.
@@ -131,7 +134,8 @@ Discord user @pig#8932 has found a working `text-chat-davinci-002` model, `text-
 - Node.js >= 16.0.0
 - npm
 - Docker (optional, for API server)
-- [OpenAI API key](https://platform.openai.com/account/api-keys)
+- [OpenAI API key](https://platform.openai.com/account/api-keys) (for `ChatGPTClient`)
+- [MiniMax API key](https://platform.minimaxi.com/) (for `MiniMaxClient`)
 
 ## Usage
 
@@ -149,6 +153,11 @@ See [`demos/use-bing-client.js`](demos/use-bing-client.js).
 <summary><strong>ChatGPTClient</strong></summary>
 
 See [`demos/use-client.js`](demos/use-client.js).
+</details>
+<details open>
+<summary><strong>MiniMaxClient</strong></summary>
+
+See [`demos/use-minimax-client.js`](demos/use-minimax-client.js).
 </details>
 <details open>
 <summary><strong>ChatGPTBrowserClient</strong></summary>
@@ -223,6 +232,17 @@ module.exports = {
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
     },
+    // Options for the MiniMax client
+    miniMaxClient: {
+        // Your MiniMax API key (for `MiniMaxClient`)
+        minimaxApiKey: process.env.MINIMAX_API_KEY || '',
+        modelOptions: {
+            // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
+            model: 'MiniMax-M2.7',
+        },
+        proxy: '',
+        debug: false,
+    },
     chatGptBrowserClient: {
         // (Optional) Support for a reverse proxy for the conversation endpoint (private API server).
         // Warning: This will expose your access token to a third party. Consider the risks before using this.
@@ -242,7 +262,7 @@ module.exports = {
         host: process.env.API_HOST || 'localhost',
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
-        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing". (Default: "chatgpt")
+        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing", "minimax". (Default: "chatgpt")
         clientToUse: 'chatgpt',
         // (Optional) Generate titles for each conversation for clients that support it (only ChatGPTClient for now).
         // This will be returned as a `title` property in the first response of the conversation.
@@ -252,7 +272,7 @@ module.exports = {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser', 'minimax'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.
@@ -304,7 +324,7 @@ Optional parameters are only necessary for conversations that span multiple requ
 | clientId                  | (Optional, for `BingAIClient` only) The ID of the client. Required when continuing a conversation unless in jailbreak mode.                                                                                                                                     |
 | invocationId              | (Optional, for `BingAIClient` only) The ID of the invocation. Required when continuing a conversation unless in jailbreak mode.                                                                                                                                 |
 | clientOptions             | (Optional) An object containing options for the client.                                                                                                                                                                                                         |
-| clientOptions.clientToUse | (Optional) The client to use for this message. Possible values: `chatgpt`, `chatgpt-browser`, `bing`.                                                                                                                                                           |
+| clientOptions.clientToUse | (Optional) The client to use for this message. Possible values: `chatgpt`, `chatgpt-browser`, `bing`, `minimax`.                                                                                                                                                           |
 | clientOptions.*           | (Optional) Any valid options for the client. For example, for `ChatGPTClient`, you can set `clientOptions.openaiApiKey` to set an API key for this message only, or `clientOptions.promptPrefix` to give the AI custom instructions for this message only, etc. |
 
 To configure which options can be changed per message (default: all), see the comments for `perMessageClientOptionsWhitelist` in `settings.example.js`.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Discord user @pig#8932 has found a working `text-chat-davinci-002` model, `text-
     - In essence, this allows you to make a chatbot with any personality you want.
     - This is currently only configurable on a global level, but I plan to add support for per-conversation customization.
   - Retains support for models like `text-davinci-003`
-- `MiniMaxClient`: support for [MiniMax](https://www.minimaxi.com/)'s models (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, etc.) via MiniMax's OpenAI-compatible API.
-  - Extends `ChatGPTClient` with MiniMax-specific defaults (API endpoint, temperature clamping, 1M context window).
+- `MiniMaxClient`: support for [MiniMax](https://www.minimaxi.com/)'s models (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) via MiniMax's OpenAI-compatible API.
+  - Extends `ChatGPTClient` with MiniMax-specific defaults (API endpoint, temperature clamping, 512K context window with up to 128K output, image input support).
   - Supports the same conversation management, streaming, and prompt customization features as `ChatGPTClient`.
 - `BingAIClient`: support for Bing's version of ChatGPT, powered by GPT-4.
   - Includes a built-in jailbreak you can activate which enables unlimited chat messages per conversation, unlimited messages per day, and brings Sydney back. 😊
@@ -237,8 +237,8 @@ module.exports = {
         // Your MiniMax API key (for `MiniMaxClient`)
         minimaxApiKey: process.env.MINIMAX_API_KEY || '',
         modelOptions: {
-            // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
-            model: 'MiniMax-M2.7',
+            // Available models: 'MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'
+            model: 'MiniMax-M3',
         },
         proxy: '',
         debug: false,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,7 @@ import inquirer from 'inquirer';
 import inquirerAutocompletePrompt from 'inquirer-autocomplete-prompt';
 import ChatGPTClient from '../src/ChatGPTClient.js';
 import BingAIClient from '../src/BingAIClient.js';
+import MiniMaxClient from '../src/MiniMaxClient.js';
 
 const arg = process.argv.find(_arg => _arg.startsWith('--settings'));
 const path = arg?.split('=')[1] ?? './settings.js';
@@ -85,6 +86,13 @@ switch (clientToUse) {
             cache: settings.cacheOptions,
         });
         break;
+    case 'minimax':
+        client = new MiniMaxClient(
+            settings.minimaxApiKey || settings.miniMaxClient?.minimaxApiKey,
+            settings.miniMaxClient || {},
+            settings.cacheOptions,
+        );
+        break;
     default:
         client = new ChatGPTClient(
             settings.openaiApiKey || settings.chatGptClient.openaiApiKey,
@@ -156,6 +164,9 @@ async function onMessage(message) {
     switch (clientToUse) {
         case 'bing':
             aiLabel = 'Bing';
+            break;
+        case 'minimax':
+            aiLabel = settings.miniMaxClient?.chatGptLabel || 'MiniMax';
             break;
         default:
             aiLabel = settings.chatGptClient?.chatGptLabel || 'ChatGPT';

--- a/bin/server.js
+++ b/bin/server.js
@@ -8,6 +8,7 @@ import { KeyvFile } from 'keyv-file';
 import ChatGPTClient from '../src/ChatGPTClient.js';
 import ChatGPTBrowserClient from '../src/ChatGPTBrowserClient.js';
 import BingAIClient from '../src/BingAIClient.js';
+import MiniMaxClient from '../src/MiniMaxClient.js';
 
 const arg = process.argv.find(_arg => _arg.startsWith('--settings'));
 const path = arg?.split('=')[1] ?? './settings.js';
@@ -140,7 +141,8 @@ server.post('/conversation', async (request, reply) => {
     } else if (settings.apiOptions?.debug) {
         console.debug(error);
     }
-    const message = error?.data?.message || error?.message || `There was an error communicating with ${clientToUse === 'bing' ? 'Bing' : 'ChatGPT'}.`;
+    const clientLabels = { bing: 'Bing', minimax: 'MiniMax', chatgpt: 'ChatGPT', 'chatgpt-browser': 'ChatGPT' };
+        const message = error?.data?.message || error?.message || `There was an error communicating with ${clientLabels[clientToUseForMessage] || 'the AI'}.`;
     if (body.stream === true) {
         reply.sse({
             id: '',
@@ -183,6 +185,12 @@ function getClient(clientToUseForMessage) {
             return new ChatGPTClient(
                 settings.openaiApiKey || settings.chatGptClient.openaiApiKey,
                 settings.chatGptClient,
+                settings.cacheOptions,
+            );
+        case 'minimax':
+            return new MiniMaxClient(
+                settings.minimaxApiKey || settings.miniMaxClient?.minimaxApiKey,
+                settings.miniMaxClient || {},
                 settings.cacheOptions,
             );
         default:

--- a/bin/server.js
+++ b/bin/server.js
@@ -78,6 +78,7 @@ server.post('/conversation', async (request, reply) => {
 
     let result;
     let error;
+    let clientToUseForMessage = clientToUse;
     try {
         if (!body.message) {
             const invalidError = new Error();
@@ -89,7 +90,6 @@ server.post('/conversation', async (request, reply) => {
             throw invalidError;
         }
 
-        let clientToUseForMessage = clientToUse;
         const clientOptions = filterClientOptions(body.clientOptions, clientToUseForMessage);
         if (clientOptions && clientOptions.clientToUse) {
             clientToUseForMessage = clientOptions.clientToUse;
@@ -141,8 +141,10 @@ server.post('/conversation', async (request, reply) => {
     } else if (settings.apiOptions?.debug) {
         console.debug(error);
     }
-    const clientLabels = { bing: 'Bing', minimax: 'MiniMax', chatgpt: 'ChatGPT', 'chatgpt-browser': 'ChatGPT' };
-        const message = error?.data?.message || error?.message || `There was an error communicating with ${clientLabels[clientToUseForMessage] || 'the AI'}.`;
+    const clientLabels = {
+        bing: 'Bing', minimax: 'MiniMax', chatgpt: 'ChatGPT', 'chatgpt-browser': 'ChatGPT',
+    };
+    const message = error?.data?.message || error?.message || `There was an error communicating with ${clientLabels[clientToUseForMessage] || 'the AI'}.`;
     if (body.stream === true) {
         reply.sse({
             id: '',

--- a/demos/use-minimax-client.js
+++ b/demos/use-minimax-client.js
@@ -1,0 +1,49 @@
+// eslint-disable-next-line no-unused-vars
+import { KeyvFile } from 'keyv-file';
+// import { MiniMaxClient } from '@waylaidwanderer/chatgpt-api';
+import { MiniMaxClient } from '../index.js';
+
+const clientOptions = {
+    // (Optional) Parameters for MiniMax's OpenAI-compatible API
+    modelOptions: {
+        // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
+        model: 'MiniMax-M2.7',
+        // MiniMax supports temperature in the range [0, 1].
+        temperature: 0,
+        // Set max_tokens here to override the default max_tokens of 4096 for the completion.
+        // max_tokens: 4096,
+    },
+    // (Optional) MiniMax-M2.7 supports up to 1M context tokens.
+    // maxContextTokens: 1000000,
+    // (Optional) Set custom instructions.
+    // promptPrefix: 'You are a helpful AI assistant powered by MiniMax...',
+    // (Optional) Set a custom name for the AI
+    // chatGptLabel: 'MiniMax',
+    // (Optional) Set to true to enable `console.debug()` logging
+    debug: false,
+};
+
+const cacheOptions = {
+    // Options for the Keyv cache, see https://www.npmjs.com/package/keyv
+    // For example, to use a JSON file (`npm i keyv-file`) as a database:
+    // store: new KeyvFile({ filename: 'cache.json' }),
+};
+
+const miniMaxClient = new MiniMaxClient('YOUR_MINIMAX_API_KEY', clientOptions, cacheOptions);
+
+let response;
+response = await miniMaxClient.sendMessage('Hello!');
+console.log(response); // { response: 'Hello! How can I assist you today?', conversationId: '...', messageId: '...' }
+
+response = await miniMaxClient.sendMessage('Write a short poem about cats.', { conversationId: response.conversationId, parentMessageId: response.messageId });
+console.log(response.response);
+console.log();
+
+response = await miniMaxClient.sendMessage('Now write it in French.', {
+    conversationId: response.conversationId,
+    parentMessageId: response.messageId,
+    // Streamed responses are supported.
+    onProgress: token => process.stdout.write(token),
+});
+console.log();
+console.log(response.response);

--- a/demos/use-minimax-client.js
+++ b/demos/use-minimax-client.js
@@ -6,15 +6,15 @@ import { MiniMaxClient } from '../index.js';
 const clientOptions = {
     // (Optional) Parameters for MiniMax's OpenAI-compatible API
     modelOptions: {
-        // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
-        model: 'MiniMax-M2.7',
+        // Available models: 'MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'
+        model: 'MiniMax-M3',
         // MiniMax supports temperature in the range [0, 1].
         temperature: 0,
         // Set max_tokens here to override the default max_tokens of 4096 for the completion.
         // max_tokens: 4096,
     },
-    // (Optional) MiniMax-M2.7 supports up to 1M context tokens.
-    // maxContextTokens: 1000000,
+    // (Optional) MiniMax-M3 supports up to 512K context tokens (max output 128K).
+    // maxContextTokens: 512000,
     // (Optional) Set custom instructions.
     // promptPrefix: 'You are a helpful AI assistant powered by MiniMax...',
     // (Optional) Set a custom name for the AI

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import ChatGPTClient from './src/ChatGPTClient.js';
 import ChatGPTBrowserClient from './src/ChatGPTBrowserClient.js';
 import BingAIClient from './src/BingAIClient.js';
+import MiniMaxClient from './src/MiniMaxClient.js';
 
-export { ChatGPTClient, ChatGPTBrowserClient, BingAIClient };
+export { ChatGPTClient, ChatGPTBrowserClient, BingAIClient, MiniMaxClient };
 export default ChatGPTClient;

--- a/index.js
+++ b/index.js
@@ -3,5 +3,7 @@ import ChatGPTBrowserClient from './src/ChatGPTBrowserClient.js';
 import BingAIClient from './src/BingAIClient.js';
 import MiniMaxClient from './src/MiniMaxClient.js';
 
-export { ChatGPTClient, ChatGPTBrowserClient, BingAIClient, MiniMaxClient };
+export {
+    ChatGPTClient, ChatGPTBrowserClient, BingAIClient, MiniMaxClient,
+};
 export default ChatGPTClient;

--- a/settings.example.js
+++ b/settings.example.js
@@ -63,16 +63,16 @@ export default {
         // (Optional) Parameters as described in https://platform.minimaxi.com/document/ChatCompletion%20v2
         modelOptions: {
             // You can override the model name and any other parameters here.
-            // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
-            // The default model is `MiniMax-M2.7`.
-            model: 'MiniMax-M2.7',
+            // Available models: 'MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'
+            // The default model is `MiniMax-M3`.
+            model: 'MiniMax-M3',
             // MiniMax supports temperature in the range [0, 1].
             // temperature: 0.8,
             // Set max_tokens here to override the default max_tokens of 4096 for the completion.
             // max_tokens: 4096,
         },
-        // (Optional) MiniMax-M2.7 supports up to 1M context tokens.
-        // maxContextTokens: 1000000,
+        // (Optional) MiniMax-M3 supports up to 512K context tokens (max output 128K).
+        // maxContextTokens: 512000,
         // (Optional) Set custom instructions instead of the default.
         // promptPrefix: 'You are a helpful AI assistant powered by MiniMax...',
         // (Optional) Set a custom name for the AI

--- a/settings.example.js
+++ b/settings.example.js
@@ -56,6 +56,32 @@ export default {
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
     },
+    // Options for the MiniMax client
+    miniMaxClient: {
+        // Your MiniMax API key (for `MiniMaxClient`)
+        minimaxApiKey: process.env.MINIMAX_API_KEY || '',
+        // (Optional) Parameters as described in https://platform.minimaxi.com/document/ChatCompletion%20v2
+        modelOptions: {
+            // You can override the model name and any other parameters here.
+            // Available models: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'
+            // The default model is `MiniMax-M2.7`.
+            model: 'MiniMax-M2.7',
+            // MiniMax supports temperature in the range [0, 1].
+            // temperature: 0.8,
+            // Set max_tokens here to override the default max_tokens of 4096 for the completion.
+            // max_tokens: 4096,
+        },
+        // (Optional) MiniMax-M2.7 supports up to 1M context tokens.
+        // maxContextTokens: 1000000,
+        // (Optional) Set custom instructions instead of the default.
+        // promptPrefix: 'You are a helpful AI assistant powered by MiniMax...',
+        // (Optional) Set a custom name for the AI
+        // chatGptLabel: 'MiniMax',
+        // A proxy string like "http://<ip>:<port>"
+        proxy: '',
+        // (Optional) Set to true to enable `console.debug()` logging
+        debug: false,
+    },
     chatGptBrowserClient: {
         // (Optional) Support for a reverse proxy for the conversation endpoint (private API server).
         // Warning: This will expose your access token to a third party. Consider the risks before using this.
@@ -75,7 +101,7 @@ export default {
         host: process.env.API_HOST || 'localhost',
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
-        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing". (Default: "chatgpt")
+        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing", "minimax". (Default: "chatgpt")
         clientToUse: 'chatgpt',
         // (Optional) Generate titles for each conversation for clients that support it (only ChatGPTClient for now).
         // This will be returned as a `title` property in the first response of the conversation.
@@ -85,7 +111,7 @@ export default {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser', 'minimax'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.
@@ -104,7 +130,7 @@ export default {
     },
     // Options for the CLI app
     cliOptions: {
-        // (Optional) Possible options: "chatgpt", "bing".
+        // (Optional) Possible options: "chatgpt", "bing", "minimax".
         // clientToUse: 'bing',
     },
 };

--- a/src/MiniMaxClient.js
+++ b/src/MiniMaxClient.js
@@ -1,6 +1,6 @@
 import ChatGPTClient from './ChatGPTClient.js';
 
-const MINIMAX_DEFAULT_MODEL = 'MiniMax-M2.7';
+const MINIMAX_DEFAULT_MODEL = 'MiniMax-M3';
 
 export default class MiniMaxClient extends ChatGPTClient {
     constructor(
@@ -56,7 +56,7 @@ export default class MiniMaxClient extends ChatGPTClient {
         this.isChatGptModel = true;
         this.isUnofficialChatGptModel = false;
 
-        this.maxContextTokens = this.options.maxContextTokens || 1000000;
+        this.maxContextTokens = this.options.maxContextTokens || 512000;
         this.maxResponseTokens = this.modelOptions.max_tokens || 4096;
         this.maxPromptTokens = this.options.maxPromptTokens || (this.maxContextTokens - this.maxResponseTokens);
 

--- a/src/MiniMaxClient.js
+++ b/src/MiniMaxClient.js
@@ -1,0 +1,190 @@
+import ChatGPTClient from './ChatGPTClient.js';
+
+const MINIMAX_DEFAULT_MODEL = 'MiniMax-M2.7';
+
+export default class MiniMaxClient extends ChatGPTClient {
+    constructor(
+        apiKey,
+        options = {},
+        cacheOptions = {},
+    ) {
+        // Set MiniMax-specific defaults before calling super
+        const miniMaxOptions = {
+            ...options,
+            modelOptions: {
+                model: MINIMAX_DEFAULT_MODEL,
+                ...options.modelOptions,
+            },
+        };
+        super(apiKey, miniMaxOptions, cacheOptions);
+    }
+
+    setOptions(options) {
+        if (this.options && !this.options.replaceOptions) {
+            this.options.modelOptions = {
+                ...this.options.modelOptions,
+                ...options.modelOptions,
+            };
+            delete options.modelOptions;
+            this.options = {
+                ...this.options,
+                ...options,
+            };
+        } else {
+            this.options = options;
+        }
+
+        if (this.options.minimaxApiKey) {
+            this.apiKey = this.options.minimaxApiKey;
+        }
+
+        const modelOptions = this.options.modelOptions || {};
+        // Clamp temperature to MiniMax's accepted range [0, 1]
+        let temperature = typeof modelOptions.temperature === 'undefined' ? 0.8 : modelOptions.temperature;
+        temperature = Math.max(0, Math.min(1, temperature));
+
+        this.modelOptions = {
+            ...modelOptions,
+            model: modelOptions.model || MINIMAX_DEFAULT_MODEL,
+            temperature,
+            top_p: typeof modelOptions.top_p === 'undefined' ? 1 : modelOptions.top_p,
+            presence_penalty: typeof modelOptions.presence_penalty === 'undefined' ? 0 : modelOptions.presence_penalty,
+            stop: modelOptions.stop,
+        };
+
+        // MiniMax models use the Chat Completions API (OpenAI-compatible)
+        this.isChatGptModel = true;
+        this.isUnofficialChatGptModel = false;
+
+        this.maxContextTokens = this.options.maxContextTokens || 1000000;
+        this.maxResponseTokens = this.modelOptions.max_tokens || 4096;
+        this.maxPromptTokens = this.options.maxPromptTokens || (this.maxContextTokens - this.maxResponseTokens);
+
+        if (this.maxPromptTokens + this.maxResponseTokens > this.maxContextTokens) {
+            throw new Error(`maxPromptTokens + max_tokens (${this.maxPromptTokens} + ${this.maxResponseTokens} = ${this.maxPromptTokens + this.maxResponseTokens}) must be less than or equal to maxContextTokens (${this.maxContextTokens})`);
+        }
+
+        this.userLabel = this.options.userLabel || 'User';
+        this.chatGptLabel = this.options.chatGptLabel || 'MiniMax';
+
+        this.startToken = '||>';
+        this.endToken = '';
+        this.gptEncoder = this.constructor.getTokenizer('cl100k_base');
+
+        if (!this.modelOptions.stop) {
+            const stopTokens = [this.startToken];
+            if (this.endToken && this.endToken !== this.startToken) {
+                stopTokens.push(this.endToken);
+            }
+            stopTokens.push(`\n${this.userLabel}:`);
+            stopTokens.push('<|diff_marker|>');
+            this.modelOptions.stop = stopTokens;
+        }
+
+        if (this.options.reverseProxyUrl) {
+            this.completionsUrl = this.options.reverseProxyUrl;
+        } else {
+            this.completionsUrl = 'https://api.minimax.io/v1/chat/completions';
+        }
+
+        return this;
+    }
+
+    /**
+     * Override buildPrompt to construct proper user/assistant role messages
+     * for MiniMax's OpenAI-compatible Chat Completions API.
+     */
+    async buildPrompt(messages, parentMessageId, { promptPrefix = null } = {}) {
+        const orderedMessages = this.constructor.getMessagesForConversation(messages, parentMessageId);
+
+        promptPrefix = (promptPrefix || this.options.promptPrefix || '').trim();
+        if (!promptPrefix) {
+            const currentDateString = new Date().toLocaleDateString(
+                'en-us',
+                { year: 'numeric', month: 'long', day: 'numeric' },
+            );
+            promptPrefix = `You are ${this.chatGptLabel}, a large language model powered by MiniMax. Respond conversationally.\nCurrent date: ${currentDateString}`;
+        }
+
+        const systemMessage = {
+            role: 'system',
+            content: promptPrefix,
+        };
+
+        let currentTokenCount = this.getTokenCount(promptPrefix) + 4; // 4 for metadata
+        const maxTokenCount = this.maxPromptTokens;
+
+        const chatMessages = [];
+        const context = [];
+
+        // Iterate backwards through the messages, adding them to the prompt
+        const buildMessages = async () => {
+            if (currentTokenCount < maxTokenCount && orderedMessages.length > 0) {
+                const message = orderedMessages.pop();
+                const role = message.role === 'User' ? 'user' : 'assistant';
+                const messageString = message.message;
+                const tokenCountForMessage = this.getTokenCount(messageString) + 4;
+                const newTokenCount = currentTokenCount + tokenCountForMessage;
+
+                if (newTokenCount > maxTokenCount) {
+                    if (chatMessages.length > 0) {
+                        return false;
+                    }
+                    throw new Error(`Prompt is too long. Max token count is ${maxTokenCount}, but prompt is ${newTokenCount} tokens long.`);
+                }
+
+                chatMessages.unshift({ role, content: messageString });
+                context.unshift(message);
+                currentTokenCount = newTokenCount;
+                await new Promise(resolve => setImmediate(resolve));
+                return buildMessages();
+            }
+            return true;
+        };
+
+        await buildMessages();
+
+        this.modelOptions.max_tokens = Math.min(
+            this.maxContextTokens - currentTokenCount,
+            this.maxResponseTokens,
+        );
+
+        const prompt = [systemMessage, ...chatMessages];
+        return { prompt, context };
+    }
+
+    async generateTitle(userMessage, botMessage) {
+        const messages = [
+            {
+                role: 'system',
+                content: 'Write an extremely concise subtitle for this conversation with no more than a few words. All words should be capitalized. Exclude punctuation.',
+            },
+            {
+                role: 'user',
+                content: userMessage.message,
+            },
+            {
+                role: 'assistant',
+                content: botMessage.message,
+            },
+            {
+                role: 'user',
+                content: 'Now write a concise title for this conversation.',
+            },
+        ];
+
+        const titleGenClientOptions = JSON.parse(JSON.stringify(this.options));
+        titleGenClientOptions.modelOptions = {
+            model: MINIMAX_DEFAULT_MODEL,
+            temperature: 0,
+            presence_penalty: 0,
+            frequency_penalty: 0,
+        };
+        const titleGenClient = new MiniMaxClient(this.apiKey, titleGenClientOptions);
+        const result = await titleGenClient.getCompletion(messages, null);
+        return result.choices[0].message.content
+            .replace(/[^a-zA-Z0-9' ]/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+}

--- a/test/minimax-client-integration.js
+++ b/test/minimax-client-integration.js
@@ -10,7 +10,7 @@ describe('MiniMaxClient Integration Tests', { skip: !MINIMAX_API_KEY ? 'MINIMAX_
     before(() => {
         client = new MiniMaxClient(MINIMAX_API_KEY, {
             modelOptions: {
-                model: 'MiniMax-M2.7',
+                model: 'MiniMax-M3',
                 temperature: 0,
                 max_tokens: 256,
             },

--- a/test/minimax-client-integration.js
+++ b/test/minimax-client-integration.js
@@ -2,7 +2,7 @@ import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import MiniMaxClient from '../src/MiniMaxClient.js';
 
-const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const { MINIMAX_API_KEY } = process.env;
 
 describe('MiniMaxClient Integration Tests', { skip: !MINIMAX_API_KEY ? 'MINIMAX_API_KEY not set' : false }, () => {
     let client;

--- a/test/minimax-client-integration.js
+++ b/test/minimax-client-integration.js
@@ -1,0 +1,51 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import MiniMaxClient from '../src/MiniMaxClient.js';
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+
+describe('MiniMaxClient Integration Tests', { skip: !MINIMAX_API_KEY ? 'MINIMAX_API_KEY not set' : false }, () => {
+    let client;
+
+    before(() => {
+        client = new MiniMaxClient(MINIMAX_API_KEY, {
+            modelOptions: {
+                model: 'MiniMax-M2.7',
+                temperature: 0,
+                max_tokens: 256,
+            },
+            maxContextTokens: 4096,
+        });
+    });
+
+    it('should send a message and receive a response', async () => {
+        const result = await client.sendMessage('Reply with exactly: "Hello from MiniMax"');
+        assert.ok(result.response);
+        assert.ok(result.conversationId);
+        assert.ok(result.messageId);
+        assert.ok(typeof result.response === 'string');
+        assert.ok(result.response.length > 0);
+    });
+
+    it('should support streaming responses', async () => {
+        const tokens = [];
+        const result = await client.sendMessage('Say "streaming works" and nothing else.', {
+            onProgress: (token) => {
+                tokens.push(token);
+            },
+        });
+        assert.ok(result.response);
+        assert.ok(tokens.length > 0, 'Should have received streaming tokens');
+    });
+
+    it('should maintain conversation context', async () => {
+        const first = await client.sendMessage('My favorite color is blue. Remember this.');
+        assert.ok(first.response);
+
+        const second = await client.sendMessage('What is my favorite color? Reply with just the color.', {
+            conversationId: first.conversationId,
+            parentMessageId: first.messageId,
+        });
+        assert.ok(second.response.toLowerCase().includes('blue'));
+    });
+});

--- a/test/minimax-client-unit.js
+++ b/test/minimax-client-unit.js
@@ -7,7 +7,7 @@ describe('MiniMaxClient', () => {
 
     beforeEach(() => {
         client = new MiniMaxClient('test-api-key', {
-            modelOptions: { model: 'MiniMax-M2.7' },
+            modelOptions: { model: 'MiniMax-M3' },
         });
     });
 
@@ -20,9 +20,9 @@ describe('MiniMaxClient', () => {
             assert.equal(client.apiKey, 'test-api-key');
         });
 
-        it('should use MiniMax-M2.7 as the default model', () => {
+        it('should use MiniMax-M3 as the default model', () => {
             const defaultClient = new MiniMaxClient('key');
-            assert.equal(defaultClient.modelOptions.model, 'MiniMax-M2.7');
+            assert.equal(defaultClient.modelOptions.model, 'MiniMax-M3');
         });
 
         it('should allow overriding the model', () => {
@@ -30,6 +30,13 @@ describe('MiniMaxClient', () => {
                 modelOptions: { model: 'MiniMax-M2.7-highspeed' },
             });
             assert.equal(customClient.modelOptions.model, 'MiniMax-M2.7-highspeed');
+        });
+
+        it('should allow selecting MiniMax-M2.7', () => {
+            const customClient = new MiniMaxClient('key', {
+                modelOptions: { model: 'MiniMax-M2.7' },
+            });
+            assert.equal(customClient.modelOptions.model, 'MiniMax-M2.7');
         });
     });
 
@@ -53,8 +60,8 @@ describe('MiniMaxClient', () => {
             assert.equal(client.isUnofficialChatGptModel, false);
         });
 
-        it('should set default maxContextTokens to 1M', () => {
-            assert.equal(client.maxContextTokens, 1000000);
+        it('should set default maxContextTokens to 512K', () => {
+            assert.equal(client.maxContextTokens, 512000);
         });
 
         it('should set default maxResponseTokens to 4096', () => {

--- a/test/minimax-client-unit.js
+++ b/test/minimax-client-unit.js
@@ -1,0 +1,215 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import MiniMaxClient from '../src/MiniMaxClient.js';
+
+describe('MiniMaxClient', () => {
+    let client;
+
+    beforeEach(() => {
+        client = new MiniMaxClient('test-api-key', {
+            modelOptions: { model: 'MiniMax-M2.7' },
+        });
+    });
+
+    describe('constructor', () => {
+        it('should create a MiniMaxClient instance', () => {
+            assert.ok(client instanceof MiniMaxClient);
+        });
+
+        it('should set the API key', () => {
+            assert.equal(client.apiKey, 'test-api-key');
+        });
+
+        it('should use MiniMax-M2.7 as the default model', () => {
+            const defaultClient = new MiniMaxClient('key');
+            assert.equal(defaultClient.modelOptions.model, 'MiniMax-M2.7');
+        });
+
+        it('should allow overriding the model', () => {
+            const customClient = new MiniMaxClient('key', {
+                modelOptions: { model: 'MiniMax-M2.7-highspeed' },
+            });
+            assert.equal(customClient.modelOptions.model, 'MiniMax-M2.7-highspeed');
+        });
+    });
+
+    describe('setOptions', () => {
+        it('should set completions URL to MiniMax API endpoint', () => {
+            assert.equal(client.completionsUrl, 'https://api.minimax.io/v1/chat/completions');
+        });
+
+        it('should use reverseProxyUrl when provided', () => {
+            const proxyClient = new MiniMaxClient('key', {
+                reverseProxyUrl: 'https://my-proxy.example.com/v1/chat/completions',
+            });
+            assert.equal(proxyClient.completionsUrl, 'https://my-proxy.example.com/v1/chat/completions');
+        });
+
+        it('should set isChatGptModel to true for Chat Completions API', () => {
+            assert.equal(client.isChatGptModel, true);
+        });
+
+        it('should set isUnofficialChatGptModel to false', () => {
+            assert.equal(client.isUnofficialChatGptModel, false);
+        });
+
+        it('should set default maxContextTokens to 1M', () => {
+            assert.equal(client.maxContextTokens, 1000000);
+        });
+
+        it('should set default maxResponseTokens to 4096', () => {
+            assert.equal(client.maxResponseTokens, 4096);
+        });
+
+        it('should set chatGptLabel to MiniMax by default', () => {
+            assert.equal(client.chatGptLabel, 'MiniMax');
+        });
+
+        it('should allow custom chatGptLabel', () => {
+            const customClient = new MiniMaxClient('key', { chatGptLabel: 'MyBot' });
+            assert.equal(customClient.chatGptLabel, 'MyBot');
+        });
+
+        it('should use minimaxApiKey from options', () => {
+            const customClient = new MiniMaxClient('initial-key', {
+                minimaxApiKey: 'overridden-key',
+            });
+            assert.equal(customClient.apiKey, 'overridden-key');
+        });
+    });
+
+    describe('temperature clamping', () => {
+        it('should clamp temperature above 1 to 1', () => {
+            const hotClient = new MiniMaxClient('key', {
+                modelOptions: { temperature: 1.5 },
+            });
+            assert.equal(hotClient.modelOptions.temperature, 1);
+        });
+
+        it('should clamp temperature below 0 to 0', () => {
+            const coldClient = new MiniMaxClient('key', {
+                modelOptions: { temperature: -0.5 },
+            });
+            assert.equal(coldClient.modelOptions.temperature, 0);
+        });
+
+        it('should accept temperature=0', () => {
+            const zeroClient = new MiniMaxClient('key', {
+                modelOptions: { temperature: 0 },
+            });
+            assert.equal(zeroClient.modelOptions.temperature, 0);
+        });
+
+        it('should accept temperature=1', () => {
+            const oneClient = new MiniMaxClient('key', {
+                modelOptions: { temperature: 1 },
+            });
+            assert.equal(oneClient.modelOptions.temperature, 1);
+        });
+
+        it('should accept temperature in valid range', () => {
+            const normalClient = new MiniMaxClient('key', {
+                modelOptions: { temperature: 0.7 },
+            });
+            assert.equal(normalClient.modelOptions.temperature, 0.7);
+        });
+
+        it('should use default temperature of 0.8', () => {
+            assert.equal(client.modelOptions.temperature, 0.8);
+        });
+    });
+
+    describe('model options', () => {
+        it('should set default presence_penalty to 0', () => {
+            assert.equal(client.modelOptions.presence_penalty, 0);
+        });
+
+        it('should set default top_p to 1', () => {
+            assert.equal(client.modelOptions.top_p, 1);
+        });
+
+        it('should use cl100k_base tokenizer', () => {
+            assert.ok(client.gptEncoder);
+        });
+
+        it('should allow custom maxContextTokens', () => {
+            const customClient = new MiniMaxClient('key', {
+                maxContextTokens: 200000,
+            });
+            assert.equal(customClient.maxContextTokens, 200000);
+        });
+
+        it('should allow custom max_tokens', () => {
+            const customClient = new MiniMaxClient('key', {
+                modelOptions: { max_tokens: 2048 },
+            });
+            assert.equal(customClient.maxResponseTokens, 2048);
+        });
+    });
+
+    describe('buildPrompt', () => {
+        it('should build chat messages array with proper roles', async () => {
+            const messages = [
+                { id: '1', parentMessageId: '0', role: 'User', message: 'Hello' },
+            ];
+            const result = await client.buildPrompt(messages, '1');
+            assert.ok(Array.isArray(result.prompt));
+            assert.equal(result.prompt.length, 2); // system + user message
+            assert.equal(result.prompt[0].role, 'system');
+            assert.equal(result.prompt[1].role, 'user');
+            assert.equal(result.prompt[1].content, 'Hello');
+        });
+
+        it('should build multi-turn conversation with user/assistant roles', async () => {
+            const messages = [
+                { id: '1', parentMessageId: '0', role: 'User', message: 'Hi' },
+                { id: '2', parentMessageId: '1', role: 'ChatGPT', message: 'Hello!' },
+                { id: '3', parentMessageId: '2', role: 'User', message: 'How are you?' },
+            ];
+            const result = await client.buildPrompt(messages, '3');
+            assert.ok(Array.isArray(result.prompt));
+            assert.equal(result.prompt.length, 4); // system + 3 messages
+            assert.equal(result.prompt[0].role, 'system');
+            assert.equal(result.prompt[1].role, 'user');
+            assert.equal(result.prompt[2].role, 'assistant');
+            assert.equal(result.prompt[3].role, 'user');
+        });
+
+        it('should use custom promptPrefix', async () => {
+            const messages = [
+                { id: '1', parentMessageId: '0', role: 'User', message: 'Hello' },
+            ];
+            const result = await client.buildPrompt(messages, '1', { promptPrefix: 'You are a pirate.' });
+            assert.equal(result.prompt[0].content, 'You are a pirate.');
+        });
+    });
+
+    describe('stop tokens', () => {
+        it('should set default stop tokens', () => {
+            assert.ok(Array.isArray(client.modelOptions.stop));
+            assert.ok(client.modelOptions.stop.includes('||>'));
+            assert.ok(client.modelOptions.stop.includes('\nUser:'));
+            assert.ok(client.modelOptions.stop.includes('<|diff_marker|>'));
+        });
+
+        it('should allow custom stop tokens', () => {
+            const customClient = new MiniMaxClient('key', {
+                modelOptions: { stop: ['<stop>'] },
+            });
+            assert.deepEqual(customClient.modelOptions.stop, ['<stop>']);
+        });
+    });
+
+    describe('maxPromptTokens validation', () => {
+        it('should throw if maxPromptTokens + max_tokens > maxContextTokens', () => {
+            assert.throws(() => {
+                // eslint-disable-next-line no-new
+                new MiniMaxClient('key', {
+                    maxContextTokens: 100,
+                    maxPromptTokens: 90,
+                    modelOptions: { max_tokens: 50 },
+                });
+            }, /must be less than or equal to maxContextTokens/);
+        });
+    });
+});

--- a/test/minimax-client-unit.js
+++ b/test/minimax-client-unit.js
@@ -157,7 +157,9 @@ describe('MiniMaxClient', () => {
     describe('buildPrompt', () => {
         it('should build chat messages array with proper roles', async () => {
             const messages = [
-                { id: '1', parentMessageId: '0', role: 'User', message: 'Hello' },
+                {
+                    id: '1', parentMessageId: '0', role: 'User', message: 'Hello',
+                },
             ];
             const result = await client.buildPrompt(messages, '1');
             assert.ok(Array.isArray(result.prompt));
@@ -169,9 +171,15 @@ describe('MiniMaxClient', () => {
 
         it('should build multi-turn conversation with user/assistant roles', async () => {
             const messages = [
-                { id: '1', parentMessageId: '0', role: 'User', message: 'Hi' },
-                { id: '2', parentMessageId: '1', role: 'ChatGPT', message: 'Hello!' },
-                { id: '3', parentMessageId: '2', role: 'User', message: 'How are you?' },
+                {
+                    id: '1', parentMessageId: '0', role: 'User', message: 'Hi',
+                },
+                {
+                    id: '2', parentMessageId: '1', role: 'ChatGPT', message: 'Hello!',
+                },
+                {
+                    id: '3', parentMessageId: '2', role: 'User', message: 'How are you?',
+                },
             ];
             const result = await client.buildPrompt(messages, '3');
             assert.ok(Array.isArray(result.prompt));
@@ -184,7 +192,9 @@ describe('MiniMaxClient', () => {
 
         it('should use custom promptPrefix', async () => {
             const messages = [
-                { id: '1', parentMessageId: '0', role: 'User', message: 'Hello' },
+                {
+                    id: '1', parentMessageId: '0', role: 'User', message: 'Hello',
+                },
             ];
             const result = await client.buildPrompt(messages, '1', { promptPrefix: 'You are a pirate.' });
             assert.equal(result.prompt[0].content, 'You are a pirate.');


### PR DESCRIPTION
## Summary

- Add `MiniMaxClient` extending `ChatGPTClient` for [MiniMax](https://www.minimaxi.com/)'s OpenAI-compatible Chat Completions API
- Default to the latest **`MiniMax-M3`** model (512K context window, up to 128K output, image input support); keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Wire MiniMax into the API server, CLI, settings, and module exports as a first-class `minimax` client option
- Temperature clamping to MiniMax's `[0, 1]` range, proper `user`/`assistant` role message construction

## Available models

| Model | Notes |
|-------|-------|
| `MiniMax-M3` *(default)* | Latest MiniMax model — 512K context, 128K max output, image input |
| `MiniMax-M2.7` | Previous generation |
| `MiniMax-M2.7-highspeed` | Previous generation, low-latency variant |

## Changes

| File | Description |
|------|-------------|
| `src/MiniMaxClient.js` | New client extending ChatGPTClient with overridden `buildPrompt` for proper chat message roles; default model set to `MiniMax-M3`, default `maxContextTokens` set to `512000` |
| `bin/server.js` | Add `minimax` case in `getClient()` factory |
| `bin/cli.js` | Add `minimax` client option with MiniMax AI label |
| `index.js` | Export `MiniMaxClient` |
| `settings.example.js` | Add `miniMaxClient` configuration section (M3 default, M2.7/M2.7-highspeed listed as alternatives) |
| `demos/use-minimax-client.js` | Usage example with M3 defaults |
| `test/minimax-client-unit.js` | Unit tests covering constructor, options, temperature clamping, buildPrompt, stop tokens (default-model assertions updated to `MiniMax-M3`, default `maxContextTokens` assertion updated to `512000`, plus a new test that overriding to `MiniMax-M2.7` still works) |
| `test/minimax-client-integration.js` | Integration tests targeting `MiniMax-M3` |
| `README.md` | Document MiniMax support with `MiniMax-M3` as the default and `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` as alternatives; note the 512K context / 128K output window |

## Why M3 as default

`MiniMax-M3` is MiniMax's latest model and supersedes the M2.x line: 512K context window, up to 128K output, and image input support. M2.7 and M2.7-highspeed are kept as user-selectable alternatives so existing deployments remain functional, while older M2.5 entries are removed since they are superseded.

## Test plan

- [x] Unit tests updated for M3 default model and 512K `maxContextTokens` (`node --test test/minimax-client-unit.js`)
- [x] Integration tests target `MiniMax-M3` (`MINIMAX_API_KEY=... node --test test/minimax-client-integration.js`)
- [x] ESLint passes on all new files
- [ ] Verify `clientToUse: 'minimax'` works in API server mode
- [ ] Verify `clientToUse: 'minimax'` works in CLI mode